### PR TITLE
chore: remove obsolete deterministic flag

### DIFF
--- a/.github/workflows/orchestration-cluster-api-release.yml
+++ b/.github/workflows/orchestration-cluster-api-release.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Install deps
         run: npm ci
       - name: Generate & Build
-        env:
-          CAMUNDA_SDK_DETERMINISTIC_BUILD: '1'
         run: npm run build
       - name: Unit Tests
         run: npm test
@@ -60,8 +58,6 @@ jobs:
           cp rest-api.source.yaml spec-snapshots/spec-${HASH}.yaml
           echo "spec snapshot: spec-snapshots/spec-${HASH}.yaml"
       - name: Write BUILDINFO (deterministic)
-        env:
-          CAMUNDA_SDK_DETERMINISTIC_BUILD: '1'
         run: npx tsx scripts/write-buildinfo.ts
       - name: Detect changes
         id: diff
@@ -131,14 +127,11 @@ jobs:
         run: npm ci
       - name: Regenerate & Build (Integrity Check)
         env:
-          CAMUNDA_SDK_DETERMINISTIC_BUILD: '1'
           CAMUNDA_SDK_SKIP_FETCH_SPEC: '1'
         run: |
           # Deterministic build without refetching upstream spec to avoid mid-release spec drift.
           npm run build
       - name: Write BUILDINFO (deterministic timestamp) BEFORE drift check
-        env:
-          CAMUNDA_SDK_DETERMINISTIC_BUILD: '1'
         run: npx tsx scripts/write-buildinfo.ts
       - name: Verify no drift (deterministic)
         run: git diff --exit-code

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Refer to `./docs/CONFIG_REFERENCE.md` for the full list of related environment v
 
 We welcome issues and pull requests. Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) guide before opening a PR to understand:
 
-- Deterministic build mode (`CAMUNDA_SDK_DETERMINISTIC_BUILD=1`)
+- Deterministic builds policy (no committed timestamps) – see CONTRIBUTING
 - Commit message conventions (Conventional Commits with enforced subject length)
 - Release workflow & how to dry‑run semantic‑release locally
 - Testing strategy (unit vs integration)
@@ -1116,29 +1116,3 @@ const client = createCamundaClient({
 ## License
 
 Apache 2.0
-
-## Deterministic Build Mode
-
-To eliminate spurious publish drift caused by timestamps and formatting churn in generated artifacts, the SDK supports a deterministic build mode gated by the environment variable `CAMUNDA_SDK_DETERMINISTIC_BUILD=1`.
-
-When set:
-
-- All generation scripts use a fixed timestamp (`1970-01-01T00:00:00.000Z`) instead of `new Date().toISOString()`.
-- Build info writer and doc generators produce stable content.
-- Upstream spec cloning still occurs, but we exclude auto-formatting of generated files via `.prettierignore` to avoid style oscillation.
-
-Release workflow strategy:
-
-1. Generate job runs with `CAMUNDA_SDK_DETERMINISTIC_BUILD=1`, producing canonical artifacts. If drift is detected they are committed on a temp branch and fast‑forwarded to `main`.
-2. Publish job re-runs the deterministic build and performs `git diff --exit-code` to assert zero drift before `semantic-release`.
-
-Local verification:
-
-```bash
-CAMUNDA_SDK_DETERMINISTIC_BUILD=1 npm run build
-git diff --exit-code  # should be clean after baseline committed
-```
-
-If you see persistent diff after following the above, ensure you have not manually edited generated files and that your local commit hooks (lint-staged) respect `.prettierignore`.
-
-Do not hand-edit files under `src/gen/`, `branding/branding-metadata.json`, `tests-integration/methods/manifest.json`, or `docs/CONFIG_REFERENCE.md`; regenerate instead.

--- a/branding/branding-metadata.json
+++ b/branding/branding-metadata.json
@@ -1,6 +1,5 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2025-11-05T05:04:50.219Z",
   "specHash": "sha256:e41213bb1e0300ca199a86b111c28915a10ba83f7a8013c6406370d30704241e",
   "generator": {
     "name": "@hey-api/openapi-ts"

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -1,7 +1,5 @@
 # Configuration Reference
 
-Generated: 2025-11-05T05:05:14.623Z
-
 | Key | Type | Default | Requirement | Flags | Description |
 |-----|------|---------|-------------|-------|-------------|
 | `CAMUNDA_REST_ADDRESS` | string | `http://localhost:8080/v2` | Optional |  | Base REST endpoint address. |

--- a/plugins/branding-plugin/plugin.ts
+++ b/plugins/branding-plugin/plugin.ts
@@ -22,7 +22,6 @@ interface BrandingMetadata {
   keys: BrandingMetadataKey[];
   arrays?: BrandingArrayMeta[];
   schemaVersion: string;
-  generatedAt: string;
   specHash: string;
 }
 
@@ -76,7 +75,7 @@ export const handler: BrandingPlugin['Handler'] = (ctx) => {
   lines.push('// branding-plugin generated');
   lines.push(`// schemaVersion=${meta.schemaVersion}`);
   lines.push(`// specHash=${meta.specHash}`);
-  lines.push(`// generatedAt=${meta.generatedAt}`);
+  // (timestamp removed for deterministic builds)
   lines.push('');
   // NOTE: We no longer emit the generic brand wrapper here; instead we patch the base
   // alias in types.gen.ts from `export type CamundaKey = string;` to the generic branded form.

--- a/scripts/generate-class-methods.ts
+++ b/scripts/generate-class-methods.ts
@@ -56,9 +56,6 @@ function isExempt(opId: string): boolean {
 }
 
 function main() {
-  const nowTs = process.env.CAMUNDA_SDK_DETERMINISTIC_BUILD
-    ? '1970-01-01T00:00:00.000Z'
-    : new Date().toISOString();
   if (!fs.existsSync(SPEC_PATH)) {
     throw new Error('[class-gen] Spec missing, skipping');
   }
@@ -178,7 +175,7 @@ function main() {
   ops.sort((a, b) => a.opId.localeCompare(b.opId));
 
   const support: string[] = [];
-  support.push('// Generated ' + nowTs);
+  support.push('// Generated');
   support.push('// Operations: ' + ops.length);
   support.push('type _RawReturn<F> = F extends (...a:any)=>Promise<infer R> ? R : never;');
   support.push(
@@ -253,7 +250,7 @@ type ${o.opId}Consistency = {
   support.push('}');
 
   const methods: string[] = [];
-  methods.push('  // Generated methods (' + nowTs + ')');
+  methods.push('  // Generated methods');
   // (createDeployment) enrichment handled inline per-call; types above exported
   for (const o of ops) {
     let jsdoc = forwardJsDoc(o, docs);

--- a/scripts/generate-config-doc.ts
+++ b/scripts/generate-config-doc.ts
@@ -29,10 +29,7 @@ function table(): string {
 }
 
 function main() {
-  const nowTs = process.env.CAMUNDA_SDK_DETERMINISTIC_BUILD
-    ? '1970-01-01T00:00:00.000Z'
-    : new Date().toISOString();
-  const md = ['# Configuration Reference', '', 'Generated: ' + nowTs, '', table(), ''].join('\n');
+  const md = ['# Configuration Reference', '', table(), ''].join('\n');
   mkdirSync('docs', { recursive: true });
   writeFileSync('docs/CONFIG_REFERENCE.md', md);
   console.log('Generated docs/CONFIG_REFERENCE.md');

--- a/scripts/generate-test-scaffolds.ts
+++ b/scripts/generate-test-scaffolds.ts
@@ -10,7 +10,6 @@ const TEST_DIR = path.join(ROOT, 'tests-integration', 'methods');
 const MANIFEST = path.join(TEST_DIR, 'manifest.json');
 
 interface Manifest {
-  generatedAt: string;
   operations: number;
   tests: number;
   missing: string[];
@@ -70,11 +69,7 @@ const missing = operations.filter(
   (op) => ignore.indexOf(op) === -1 && !finalFiles.includes(`${op}.test.ts`)
 );
 
-const nowTs = process.env.CAMUNDA_SDK_DETERMINISTIC_BUILD
-  ? '1970-01-01T00:00:00.000Z'
-  : new Date().toISOString();
 const manifest: Manifest = {
-  generatedAt: nowTs,
   operations: operations.length,
   tests: finalFiles.length,
   missing: missing.map((m) => `${m}.test.ts`),

--- a/scripts/preprocess-brands.ts
+++ b/scripts/preprocess-brands.ts
@@ -79,7 +79,6 @@ interface UnionKeyEntry {
 
 interface BrandingMetadata {
   schemaVersion: string;
-  generatedAt: string;
   specHash: string;
   generator: { name: string; version?: string };
   brandingConfig: {
@@ -331,12 +330,8 @@ for (const [name, schema] of Object.entries<any>(schemas)) {
 }
 
 // Integrity counters
-const nowTs = process.env.CAMUNDA_SDK_DETERMINISTIC_BUILD
-  ? '1970-01-01T00:00:00.000Z'
-  : new Date().toISOString();
 const metadata: BrandingMetadata = {
   schemaVersion: '1.0.0',
-  generatedAt: nowTs,
   specHash,
   generator: { name: '@hey-api/openapi-ts' },
   brandingConfig: {

--- a/scripts/write-buildinfo.ts
+++ b/scripts/write-buildinfo.ts
@@ -12,11 +12,8 @@ const specHash = fs.existsSync(specPath) ? sha256(specPath) : 'absent';
 const brandingMeta = path.resolve('branding/branding-metadata.json');
 const brandingHash = fs.existsSync(brandingMeta) ? sha256(brandingMeta) : 'absent';
 
-const now = process.env.CAMUNDA_SDK_DETERMINISTIC_BUILD
-  ? '1970-01-01T00:00:00.000Z'
-  : new Date().toISOString();
 const info = {
-  generatedAt: now,
+  generatedAt: new Date().toISOString(),
   commit: process.env.GITHUB_SHA || 'local',
   workflowRun: process.env.GITHUB_RUN_ID || 'local',
   node: process.version,

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -42,7 +42,7 @@ function deepFreeze<T>(obj: T): T {
 }
 
 // === AUTO-GENERATED CAMUNDA SUPPORT TYPES START ===
-// Generated 2025-11-05T05:04:53.426Z
+// Generated
 // Operations: 146
 type _RawReturn<F> = F extends (...a:any)=>Promise<infer R> ? R : never;
 type _DataOf<F> = Exclude<_RawReturn<F> extends { data: infer D } ? D : _RawReturn<F>, undefined>;
@@ -1373,7 +1373,7 @@ export class CamundaClient {
     }
   }
   // === AUTO-GENERATED CAMUNDA METHODS START ===
-  // Generated methods (2025-11-05T05:04:53.426Z)
+  // Generated methods
   /**
    * Activate activities within an ad-hoc sub-process
    * Activates selected activities within an ad-hoc sub-process identified by element ID.

--- a/src/gen/types.gen.ts
+++ b/src/gen/types.gen.ts
@@ -12067,7 +12067,6 @@ export type ClientOptions = {
 // branding-plugin generated
 // schemaVersion=1.0.0
 // specHash=sha256:e41213bb1e0300ca199a86b111c28915a10ba83f7a8013c6406370d30704241e
-// generatedAt=2025-11-05T05:04:50.219Z
 
 export function assertConstraint(value: string, label: string, c: { pattern?: string; minLength?: number; maxLength?: number }) {
   if (c.pattern && !(new RegExp(c.pattern).test(value))) throw new Error(`[31mInvalid pattern for ${label}: '${value}'.[0m Needs to match: ${JSON.stringify(c)}

--- a/tests-integration/methods/manifest.json
+++ b/tests-integration/methods/manifest.json
@@ -1,5 +1,4 @@
 {
-  "generatedAt": "2025-11-05T05:04:56.369Z",
   "operations": 146,
   "tests": 147,
   "missing": [],


### PR DESCRIPTION
Stabilise deterministic builds by removing timestamps from generated artefacts.