### PR TITLE
style: apply biome formatting to job corrections examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,11 +613,14 @@ To deny a task completion (reject the work):
 <!-- snippet:ReadmeJobCorrectionsDenial -->
 
 ```ts
-return job.complete({}, {
-  type: 'userTask',
-  denied: true,
-  deniedReason: 'Insufficient documentation',
-});
+return job.complete(
+  {},
+  {
+    type: 'userTask',
+    denied: true,
+    deniedReason: 'Insufficient documentation',
+  }
+);
 ```
 
 | Correctable attribute | Type | Clear value |

--- a/examples/readme.ts
+++ b/examples/readme.ts
@@ -9,8 +9,8 @@ import createCamundaClient, {
   isOk,
   isSdkError,
   type JobActionReceipt,
-  type JobResult,
   JobKey,
+  type JobResult,
   ProcessDefinitionId,
   ProcessDefinitionKey,
   type ProcessInstanceKey,
@@ -249,11 +249,14 @@ async function _readmeJobCorrectionsDenial() {
     maxParallelJobs: 5,
     jobHandler: async (job) => {
       //#region ReadmeJobCorrectionsDenial
-      return job.complete({}, {
-        type: 'userTask',
-        denied: true,
-        deniedReason: 'Insufficient documentation',
-      });
+      return job.complete(
+        {},
+        {
+          type: 'userTask',
+          denied: true,
+          deniedReason: 'Insufficient documentation',
+        }
+      );
       //#endregion ReadmeJobCorrectionsDenial
     },
   });


### PR DESCRIPTION
Biome formatter ran during the pre-commit hook on #85 but the reformatted version wasn't re-staged before the commit completed, so the formatting changes ended up as unstaged diffs after merge.

This applies those changes:
- Reorders `type JobResult` import to match biome's sort order in `examples/readme.ts`
- Reformats `job.complete({}, {...})` call with arguments on separate lines
- Re-syncs the `ReadmeJobCorrectionsDenial` README snippet to match

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>