### PR TITLE
fix(runtime): annotate worker 'error' callback parameter as Error

### DIFF
--- a/src/runtime/threadPool.ts
+++ b/src/runtime/threadPool.ts
@@ -201,7 +201,7 @@ export class ThreadPool {
       }
     });
 
-    worker.on('error', (err) => {
+    worker.on('error', (err: Error) => {
       this._log.error('thread.error', err);
       this._rejectWorkerTask(pw, `Worker thread error: ${err.message}`);
       pw.ready = false;


### PR DESCRIPTION
## Summary

Add an explicit `Error` annotation to the `worker.on('error', ...)` callback parameter in `src/runtime/threadPool.ts`. Unblocks Dependabot PR #152 (`@types/node` 20→25).

Refs #155.

## Why

`@types/node` v22+ tightened the `EventEmitter` `'error'` listener parameter typing — the callback argument is now inferred as `unknown` rather than `any`. Without an annotation, the body's `err.message` / `err.stack` accesses raise `TS18046: 'err' is of type 'unknown'`.

Although `package.json` pins `^20.14.9`, the lockfile resolved transitively to `25.6.0` locally (and PR #152 makes that the explicit pin), reproducing the failure.

## Fix

```ts
worker.on('error', (err: Error) => { ... })
```

Node's `Worker` only ever emits `Error` instances on `'error'` (per Node docs and the runtime's actual usage), so the explicit annotation is sound. This is the minimal, semantically-correct change.

## Verification

- ✅ Typechecks cleanly under both `@types/node` `^20.14.9` (current pin) and `^25.6.0` (PR #152's pin).
- ✅ Full build + test suite passes locally.
- ✅ No behavioral change.

## Risk

Trivial — single-file type annotation, no runtime change.