### PR TITLE
fix(gen): forward-compatible generation hooks for @hey-api/openapi-ts 0.96 (backport #157 to stable/9)

### DIFF
--- a/hooks/post/100-fix-gen-index.ts
+++ b/hooks/post/100-fix-gen-index.ts
@@ -6,15 +6,32 @@ const GEN_INDEX_PATH = path.resolve(process.cwd(), 'src', 'gen', 'index.ts');
 function main(): void {
   const original = fs.readFileSync(GEN_INDEX_PATH, 'utf8');
 
-  // We need runtime key helper namespaces emitted into `types.gen.ts` to be
-  // reachable from `src/gen` consumers. openapi-ts generates `export type *` here
-  // which strips runtime exports.
-  const updated = original.replace(
-    "export type * from './types.gen';",
-    "export * from './types.gen';"
-  );
+  // We need runtime key helper namespaces emitted into `types.gen.ts` (e.g. the
+  // CamundaKey branding namespaces such as `ProcessInstanceKey.assumeExists`) to be
+  // reachable from `src/gen` consumers.
+  //
+  // hey-api 0.86 emits `export type * from './types.gen';` which strips runtime exports.
+  // hey-api 0.96+ emits an explicit `export type { Foo, Bar, ... } from './types.gen';`
+  // which also strips runtime exports.
+  //
+  // In the legacy form, swap the wildcard `type *` to `*` so values flow through.
+  // In the explicit form, append a `export * from './types.gen';` line so the runtime
+  // namespaces are re-exported alongside the existing explicit type re-exports.
+  let updated = original;
+  let changed = false;
+  if (updated.includes("export type * from './types.gen';")) {
+    updated = updated.replace("export type * from './types.gen';", "export * from './types.gen';");
+    changed = true;
+  } else if (
+    /export type \{[^}]+\}\s*from\s*'\.\/types\.gen';/.test(updated) &&
+    !updated.includes("export * from './types.gen';")
+  ) {
+    if (!updated.endsWith('\n')) updated += '\n';
+    updated += "export * from './types.gen';\n";
+    changed = true;
+  }
 
-  if (updated !== original) {
+  if (changed) {
     fs.writeFileSync(GEN_INDEX_PATH, updated, 'utf8');
     console.log('[postprocess-gen-index] Enabled runtime exports from types.gen');
   } else {

--- a/hooks/post/200-fix-deployment-schema.ts
+++ b/hooks/post/200-fix-deployment-schema.ts
@@ -13,13 +13,23 @@ if (!fs.existsSync(file)) {
 }
 let text = fs.readFileSync(file, 'utf8');
 
-const marker = 'export const zCreateDeploymentData = z.object({';
-const idx = text.indexOf(marker);
-if (idx === -1) {
-  console.error('[postprocess-deployment-schema] zCreateDeploymentData not found, skipping');
-  process.exit(0);
+// hey-api 0.86 emits `zCreateDeploymentData` (envelope); 0.96+ emits `zCreateDeploymentBody`
+// (body-only). Accept either; fail loud if neither is present so generator upgrades that
+// rename the schema again surface immediately instead of silently shipping an unpatched
+// File-rejecting resources schema.
+const markers = [
+  'export const zCreateDeploymentData = z.object({',
+  'export const zCreateDeploymentBody = z.object({',
+];
+const matchedMarker = markers.find((m) => text.indexOf(m) !== -1);
+if (!matchedMarker) {
+  throw new Error(
+    '[postprocess-deployment-schema] No createDeployment schema marker found ' +
+      `(looked for: ${markers.join(', ')}). The hey-api generator likely renamed the ` +
+      'schema; update this hook to match the new name.'
+  );
 }
-// Regex targets the resources: z.array(z.string())... block inside zCreateDeploymentData body definition.
+// Regex targets the resources: z.array(z.string())... block inside the createDeployment schema.
 const resourcesRegex = /(resources:\s*z\.array\(z\.string\(\)\)[^}]*)/m;
 if (!resourcesRegex.test(text)) {
   console.warn(
@@ -29,5 +39,7 @@ if (!resourcesRegex.test(text)) {
   const replacement = `resources: z.array(\n            z.any().refine(\n                (v) => (typeof File !== 'undefined' && v instanceof File),\n                { message: 'Expected File (with a filename & extension)' }\n            )\n        ).nonempty().register(z.globalRegistry, {`;
   text = text.replace(resourcesRegex, replacement);
   fs.writeFileSync(file, text, 'utf8');
-  console.log('[postprocess-deployment-schema] patched createDeployment resources schema');
+  console.log(
+    `[postprocess-deployment-schema] patched createDeployment resources schema (matched: ${matchedMarker.slice(13, matchedMarker.indexOf(' = '))})`
+  );
 }

--- a/hooks/post/300-generate-class-methods.ts
+++ b/hooks/post/300-generate-class-methods.ts
@@ -43,7 +43,7 @@ async function main() {
     while ((m = re.exec(sdk))) docs[m[2]] = `/**${m[1]}*/`;
   }
   // Collect available exported zod response schema names to avoid emitting invalid references
-  const availableResponses = new Set<string>();
+  const availableSchemas = new Set<string>();
   const voidResponses = new Set<string>();
   const ZOD_GEN_PATH = path.join(ROOT, 'src/gen/zod.gen.ts');
   if (fs.existsSync(ZOD_GEN_PATH)) {
@@ -53,7 +53,7 @@ async function main() {
     while ((mm = rResp.exec(zsrc))) {
       const name = mm[1];
       const rhs = mm[2];
-      availableResponses.add(name);
+      availableSchemas.add(name);
       // Only classify as void if the schema is pure z.void(), not a z.union
       // that happens to contain z.void() alongside data types (e.g. 200+204).
       if (/z\.void\s*\(\)/.test(rhs) && !/z\.union\s*\(/.test(rhs)) voidResponses.add(name);
@@ -276,8 +276,8 @@ export type ${o.opId}Consistency = {
       const opCap = o.opId.charAt(0).toUpperCase() + o.opId.slice(1);
       const dataName = `z${opCap}Data`;
       const bodyName = `z${opCap}Body`;
-      const useDataEnvelope = availableResponses.has(dataName);
-      const useBodyOnly = !useDataEnvelope && availableResponses.has(bodyName);
+      const useDataEnvelope = availableSchemas.has(dataName);
+      const useBodyOnly = !useDataEnvelope && availableSchemas.has(bodyName);
       methods.push(`      if (this._validation.settings.req !== 'none') {`);
       methods.push(`        const _schemas = await this._loadSchemas();`);
       if (useDataEnvelope) {
@@ -344,7 +344,7 @@ export type ${o.opId}Consistency = {
       methods.push('        }');
       // Response validation (guarded) occurs BEFORE any enrichment so fanatical mode sees raw spec shape
       const respName = `z${o.opId.charAt(0).toUpperCase() + o.opId.slice(1)}Response`;
-      if (availableResponses.has(respName)) {
+      if (availableSchemas.has(respName)) {
         methods.push("        if (this._validation.settings.res !== 'none') {");
         methods.push(`          const _schemas = await this._loadSchemas();`);
         methods.push(`          const _schema = _schemas.${respName};`);
@@ -440,7 +440,7 @@ export type ${o.opId}Consistency = {
       methods.push('          data = undefined;');
       methods.push('        }');
       const respName2 = `z${o.opId.charAt(0).toUpperCase() + o.opId.slice(1)}Response`;
-      if (availableResponses.has(respName2)) {
+      if (availableSchemas.has(respName2)) {
         methods.push("        if (this._validation.settings.res !== 'none') {");
         methods.push(`          const _schemas = await this._loadSchemas();`);
         methods.push(`          const _schema = _schemas.${respName2};`);

--- a/hooks/post/300-generate-class-methods.ts
+++ b/hooks/post/300-generate-class-methods.ts
@@ -264,14 +264,41 @@ export type ${o.opId}Consistency = {
         );
         methods.push('      }');
       }
-      // Request validation against full envelope schema (lazy-loads zod schemas on first use)
-      const reqSchemaName = `z${o.opId.charAt(0).toUpperCase() + o.opId.slice(1)}Data`;
+      // Request validation against the full envelope schema (lazy-loads zod schemas on first use).
+      // hey-api 0.86 emits a single `z<OpId>Data` envelope schema; hey-api 0.96+ splits this into
+      // `z<OpId>Body` / `z<OpId>Path` / `z<OpId>Query`. We emit different validation code per case:
+      //   * Data present  → validate the full envelope (path + query + body together).
+      //   * Body present  → validate `envelope.body` against the body schema and assign back.
+      //   * Neither       → no-op (gateRequest accepts an undefined schema).
+      // The Body fallback intentionally drops path/query validation so that backporting this
+      // generator-only patch to branches still pinned to hey-api 0.86 is safe (Data branch is
+      // taken there) while letting hey-api 0.96+ generators succeed without per-part composition.
+      const opCap = o.opId.charAt(0).toUpperCase() + o.opId.slice(1);
+      const dataName = `z${opCap}Data`;
+      const bodyName = `z${opCap}Body`;
+      const useDataEnvelope = availableResponses.has(dataName);
+      const useBodyOnly = !useDataEnvelope && availableResponses.has(bodyName);
       methods.push(`      if (this._validation.settings.req !== 'none') {`);
       methods.push(`        const _schemas = await this._loadSchemas();`);
-      methods.push(
-        `        const maybe = await this._validation.gateRequest('${o.originalOpId}', _schemas.${reqSchemaName}, envelope);`
-      );
-      methods.push(`        if (this._validation.settings.req === 'strict') envelope = maybe;`);
+      if (useDataEnvelope) {
+        methods.push(
+          `        const maybe = await this._validation.gateRequest('${o.originalOpId}', _schemas.${dataName}, envelope);`
+        );
+        methods.push(`        if (this._validation.settings.req === 'strict') envelope = maybe;`);
+      } else if (useBodyOnly) {
+        methods.push(`        if (envelope.body !== undefined) {`);
+        methods.push(
+          `          const maybeBody = await this._validation.gateRequest('${o.originalOpId}', _schemas.${bodyName}, envelope.body);`
+        );
+        methods.push(
+          `          if (this._validation.settings.req === 'strict') envelope.body = maybeBody;`
+        );
+        methods.push(`        }`);
+      } else {
+        methods.push(
+          `        await this._validation.gateRequest('${o.originalOpId}', undefined, envelope);`
+        );
+      }
       methods.push('      }');
       // Build options for SDK call
       methods.push(

--- a/hooks/post/500-gate-validation.ts
+++ b/hooks/post/500-gate-validation.ts
@@ -39,6 +39,47 @@ code = code.replace(
   'responseValidator: undefined,'
 );
 
+// hey-api 0.96+ emits validators as arrow-expression bodies (no braces) of the form:
+//   requestValidator: async (data) => await z.object({ body: ..., path: ..., query: ... }).parseAsync(data),
+//   responseValidator: async (data) => await zXxxResponse.parseAsync(data),
+// Strip these too so we don't double-validate (and so sdk.gen.ts doesn't reference
+// per-part schemas like zXxxBody / zXxxQuery / zXxxResponse that are no longer imported).
+code = stripExpressionValidators(code, 'requestValidator');
+code = stripExpressionValidators(code, 'responseValidator');
+
+function stripExpressionValidators(
+  src: string,
+  kind: 'requestValidator' | 'responseValidator'
+): string {
+  const needle = `${kind}: async (data) => await `;
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const idx = src.indexOf(needle, i);
+    if (idx === -1) {
+      out += src.slice(i);
+      break;
+    }
+    out += src.slice(i, idx);
+    // Scan from end of `await ` until we find a `,` at paren/brace depth 0.
+    let j = idx + needle.length;
+    let depthParen = 0;
+    let depthBrace = 0;
+    while (j < src.length) {
+      const ch = src[j];
+      if (ch === '(') depthParen++;
+      else if (ch === ')') depthParen--;
+      else if (ch === '{') depthBrace++;
+      else if (ch === '}') depthBrace--;
+      else if (ch === ',' && depthParen === 0 && depthBrace === 0) break;
+      j++;
+    }
+    out += `${kind}: undefined`;
+    i = j; // leave the trailing `,` in place
+  }
+  return out;
+}
+
 // Strip the zod.gen import line — validators are neutralized so the import is dead code.
 // Removing it prevents sdk.gen.ts from eagerly loading the 10K-line zod schema module.
 code = code.replace(/^import\s*\{[^}]*\}\s*from\s*'\.\/zod\.gen';\s*\n/m, '');

--- a/hooks/post/620-fix-int64-bigint.ts
+++ b/hooks/post/620-fix-int64-bigint.ts
@@ -34,8 +34,11 @@ let patched = source.replaceAll('z.coerce.bigint()', 'z.coerce.number().int()');
 
 // Also replace BigInt(...) literals used in .default(), .gte(), .min(), .max()
 // constraints — these are invalid on z.number() and should be plain numbers.
-const bigIntLiteralCount = (patched.match(/BigInt\(\s*[\d-]+\s*\)/g) ?? []).length;
-patched = patched.replace(/BigInt\(\s*([\d-]+)\s*\)/g, '$1');
+// hey-api 0.86 emits `BigInt(123)` (numeric arg); hey-api 0.96+ emits
+// `BigInt('123')` (string arg). Match both forms.
+const bigIntLiteralRe = /BigInt\(\s*['"]?(-?\d+)['"]?\s*\)/g;
+const bigIntLiteralCount = (patched.match(bigIntLiteralRe) ?? []).length;
+patched = patched.replace(bigIntLiteralRe, '$1');
 
 const count = (source.match(/z\.coerce\.bigint\(\)/g) ?? []).length;
 const didPatch = count > 0 || bigIntLiteralCount > 0;

--- a/tests/lazy-schema-loading.test.ts
+++ b/tests/lazy-schema-loading.test.ts
@@ -31,7 +31,11 @@ describe('lazy schema loading', () => {
     // Trigger schema loading manually
     const schemas = await (client as any)._loadSchemas();
     expect(schemas).toBeDefined();
-    expect(typeof schemas.zCreateProcessInstanceData).toBe('object');
+    // hey-api 0.86 emits `zCreateProcessInstanceData` (envelope); 0.96+ emits
+    // `zCreateProcessInstanceBody` (body-only). Either name proves schemas loaded.
+    const createProcessInstanceSchema =
+      schemas.zCreateProcessInstanceData ?? schemas.zCreateProcessInstanceBody;
+    expect(typeof createProcessInstanceSchema).toBe('object');
     // After first load, the promise should be cached
     expect((client as any)._schemasPromise).not.toBeNull();
     // Second call returns same cached module


### PR DESCRIPTION
## Summary

Backport of #157 to `stable/9`.

Cherry-picks commit `cb1bdddf7` from `main`. Makes generation hooks forward-compatible with `@hey-api/openapi-ts` 0.96 so Dependabot can bump the generator on `stable/9` without breaking the build.

Refs #155.

## Why this is needed on stable/9

`stable/9`'s release CI (`.github/workflows/release.yml` lines 117-125) auto-commits `src/gen/*` drift as `fix(gen): regenerate artifacts` and then publishes via semantic-release. With these hook fixes in place, when Dependabot opens a PR on `stable/9` bumping `@hey-api/openapi-ts` to 0.96, CI will:

1. Regenerate `src/gen/*` against the new generator (now succeeds because the hooks handle 0.96's output shape).
2. Auto-commit the regenerated artifacts.
3. Publish a 9.x patch release.

Without this backport, every Dependabot PR on `stable/9` for `@hey-api/openapi-ts` 0.96 fails CI exactly as it did on `main` in #148.

## Changes

Generator-hooks-only — see #157 for the full per-file rationale. Verified clean cherry-pick (no conflicts).

## Verification

- ✅ Cherry-pick applied cleanly with `git cherry-pick cb1bdddf7` — no conflicts.
- ✅ Output is byte-identical under the currently pinned `@hey-api/openapi-ts` version (verified on `main`).
- ✅ Forward-compat verified end-to-end on `main` against `^0.96.0` (full build + test green).

## Risk

Very low. Pure forward-compat in hooks. No runtime, no public API, no `src/gen/` change under the current pin. Identical change to #157 (already verified on `main`).