### PR TITLE
fix(runtime): annotate worker 'error' callback parameter as Error (backport #158 to stable/9)

### DIFF
--- a/src/runtime/threadPool.ts
+++ b/src/runtime/threadPool.ts
@@ -201,7 +201,7 @@ export class ThreadPool {
       }
     });
 
-    worker.on('error', (err) => {
+    worker.on('error', (err: Error) => {
       this._log.error('thread.error', err);
       this._rejectWorkerTask(pw, `Worker thread error: ${err.message}`);
       pw.ready = false;


### PR DESCRIPTION
## Summary

Backport of #158 to `stable/9`.

Cherry-picks commit `7b3a58a0c` from `main`. Adds `Error` type annotation on the `worker.on('error', ...)` callback in `src/runtime/threadPool.ts` so the build passes under `@types/node` v22+.

Refs #155.

## Why this is needed on stable/9

Dependabot will open the same `@types/node` 20→25 bump on `stable/9` and it will fail with `TS18046: 'err' is of type 'unknown'` in `threadPool.ts`, exactly as on `main` in #152. This backport unblocks that.

## Verification

- ✅ Cherry-pick applied cleanly with `git cherry-pick 7b3a58a0c` — no conflicts.
- ✅ Verified end-to-end on `main` under both `@types/node` `^20.14.9` and `^25.6.0`.

## Risk

Trivial — single-file type annotation, no behavioral change.