### PR TITLE
fix(gen): apply CAMUNDA_DEFAULT_TENANT_ID to activateJobs tenantIds (#170)

### DIFF
--- a/hooks/post/300-generate-class-methods.ts
+++ b/hooks/post/300-generate-class-methods.ts
@@ -3,9 +3,80 @@ import path from 'node:path';
 
 const ROOT = process.cwd();
 const METADATA_PATH = path.join(ROOT, 'external-spec/bundled/spec-metadata.json');
+const BUNDLED_SPEC_PATH = path.join(ROOT, 'external-spec/bundled/rest-api.bundle.json');
 const TEMPLATE_FILE = path.join(ROOT, 'src/template/CamundaClient.template.ts');
 const CLASS_FILE = path.join(ROOT, 'src/gen/CamundaClient.ts');
 const SDK_GEN_PATH = path.join(ROOT, 'src/gen/sdk.gen.ts');
+
+/**
+ * Detect operations whose request body has an optional `tenantIds: array`
+ * property. Mirrors `optionalTenantIdInBody` (singular) from the bundler
+ * metadata, but for the plural array case (e.g. `activateJobs`).
+ *
+ * Sourced from the bundled spec rather than spec-metadata.json so this hook
+ * remains self-contained and does not require a `camunda-schema-bundler`
+ * release. See issue #170.
+ */
+function collectOpsWithOptionalTenantIdsArray(): Set<string> {
+  const result = new Set<string>();
+  if (!fs.existsSync(BUNDLED_SPEC_PATH)) return result;
+  const spec = JSON.parse(fs.readFileSync(BUNDLED_SPEC_PATH, 'utf8'));
+  const componentSchemas = (spec?.components?.schemas || {}) as Record<
+    string,
+    Record<string, unknown>
+  >;
+
+  function resolveSchemaRef(
+    schema: Record<string, unknown> | undefined
+  ): Record<string, unknown> | undefined {
+    if (!schema) return undefined;
+    if (typeof schema['$ref'] === 'string') {
+      const name = (schema['$ref'] as string).split('/').pop()!;
+      return componentSchemas[name];
+    }
+    return schema;
+  }
+
+  function hasOptionalTenantIdsArray(schema: Record<string, unknown> | undefined): boolean {
+    if (!schema || schema['type'] !== 'object') return false;
+    const props = schema['properties'] as Record<string, Record<string, unknown>> | undefined;
+    if (!props || !props['tenantIds']) return false;
+    const required = (schema['required'] as string[] | undefined) ?? [];
+    if (required.includes('tenantIds')) return false;
+    return props['tenantIds']['type'] === 'array';
+  }
+
+  const paths = (spec?.paths || {}) as Record<string, Record<string, unknown>>;
+  for (const methods of Object.values(paths)) {
+    for (const op of Object.values(methods)) {
+      const opObj = op as Record<string, unknown>;
+      const opId = opObj['operationId'] as string | undefined;
+      if (!opId) continue;
+      const rb = opObj['requestBody'] as Record<string, unknown> | undefined;
+      const content = rb?.['content'] as Record<string, unknown> | undefined;
+      if (!content) continue;
+      for (const [ct, mediaObj] of Object.entries(content)) {
+        if (!/json/i.test(ct)) continue;
+        const media = mediaObj as Record<string, unknown> | undefined;
+        const rawSchema = media?.['schema'] as Record<string, unknown> | undefined;
+        const resolved = resolveSchemaRef(rawSchema);
+        if (!resolved) continue;
+        const variants = (resolved['oneOf'] || resolved['anyOf']) as
+          | Record<string, unknown>[]
+          | undefined;
+        if (Array.isArray(variants) && variants.length > 1) {
+          const all =
+            variants.length > 0 &&
+            variants.map((v) => resolveSchemaRef(v)).every((rs) => hasOptionalTenantIdsArray(rs));
+          if (all) result.add(opId);
+        } else if (hasOptionalTenantIdsArray(resolved)) {
+          result.add(opId);
+        }
+      }
+    }
+  }
+  return result;
+}
 
 const MARK_TYPES_START = '// === AUTO-GENERATED CAMUNDA SUPPORT TYPES START ===';
 const MARK_TYPES_END = '// === AUTO-GENERATED CAMUNDA SUPPORT TYPES END ===';
@@ -74,8 +145,10 @@ async function main() {
     pathParams: string[];
     queryParams: Array<{ name: string; required: boolean }>;
     optionalTenantIdInBody: boolean;
+    optionalTenantIdsInBody: boolean;
   }
   const ops: OpMeta[] = [];
+  const opsWithTenantIdsArray = collectOpsWithOptionalTenantIdsArray();
   for (const op of metadata.operations) {
     const originalId = op.operationId;
     const opId = sanitize(originalId);
@@ -93,6 +166,7 @@ async function main() {
       pathParams: op.pathParams || [],
       queryParams: op.queryParams || [],
       optionalTenantIdInBody: op.optionalTenantIdInBody || false,
+      optionalTenantIdsInBody: opsWithTenantIdsArray.has(originalId),
     });
   }
   ops.sort((a, b) => a.opId.localeCompare(b.opId));
@@ -261,6 +335,21 @@ export type ${o.opId}Consistency = {
           "        this._log.trace(() => ['tenant.default.inject', { op: '" +
             o.originalOpId +
             "', tenant: this._config.defaultTenantId }]);"
+        );
+        methods.push('      }');
+      }
+      if (o.hasBody && o.optionalTenantIdsInBody) {
+        // Inject [defaultTenantId] when caller omits tenantIds (or passes empty array).
+        // Only inject when a default tenant is configured — otherwise leave the field
+        // absent so downstream behavior matches "no default" semantics. See issue #170.
+        methods.push(
+          '      if (envelope.body && this._config.defaultTenantId !== undefined && this._config.defaultTenantId !== null && (!Array.isArray(envelope.body.tenantIds) || envelope.body.tenantIds.length === 0)) {'
+        );
+        methods.push('        envelope.body.tenantIds = [this._config.defaultTenantId];');
+        methods.push(
+          "        this._log.trace(() => ['tenant.default.inject', { op: '" +
+            o.originalOpId +
+            "', tenantIds: [this._config.defaultTenantId] }]);"
         );
         methods.push('      }');
       }

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -1716,6 +1716,10 @@ export class CamundaClient {
       const _body = arg;
       let envelope: any = {};
       envelope.body = _body;
+      if (envelope.body && this._config.defaultTenantId !== undefined && this._config.defaultTenantId !== null && (!Array.isArray(envelope.body.tenantIds) || envelope.body.tenantIds.length === 0)) {
+        envelope.body.tenantIds = [this._config.defaultTenantId];
+        this._log.trace(() => ['tenant.default.inject', { op: 'activateJobs', tenantIds: [this._config.defaultTenantId] }]);
+      }
       if (this._validation.settings.req !== 'none') {
         const _schemas = await this._loadSchemas();
         const maybe = await this._validation.gateRequest('activateJobs', _schemas.zActivateJobsData, envelope);

--- a/tests/activate-jobs-default-tenant-ids.test.ts
+++ b/tests/activate-jobs-default-tenant-ids.test.ts
@@ -1,0 +1,228 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { createCamundaClient } from '../src';
+
+/**
+ * Regression for #170 — `CAMUNDA_DEFAULT_TENANT_ID` was not applied to
+ * `activateJobs` requests. Existing tenant-default injection only handled
+ * the singular `tenantId` body field; operations with optional `tenantIds`
+ * (plural array, e.g. `activateJobs`) were not covered.
+ *
+ * Class-of-defect: any operation whose request body has an optional
+ * `tenantIds: TenantId[]` field must, when caller omits it, default to
+ * `[config.defaultTenantId]` if a default tenant is configured.
+ *
+ * activateJobs is currently the only operation matching this shape, but the
+ * structural guard scans the bundled spec so the same defect cannot recur in
+ * a sibling operation without being caught.
+ */
+
+interface BundledOp {
+  operationId?: string;
+  requestBody?: {
+    content?: Record<string, { schema?: Record<string, unknown> }>;
+  };
+}
+
+interface BundledSpec {
+  paths: Record<string, Record<string, BundledOp>>;
+  components: { schemas: Record<string, Record<string, unknown>> };
+}
+
+function loadBundledSpec(): BundledSpec {
+  const p = join(__dirname, '..', 'external-spec', 'bundled', 'rest-api.bundle.json');
+  return JSON.parse(readFileSync(p, 'utf8'));
+}
+
+function resolveSchema(
+  schema: Record<string, unknown> | undefined,
+  schemas: Record<string, Record<string, unknown>>
+): Record<string, unknown> | undefined {
+  if (!schema) return undefined;
+  if (typeof schema.$ref === 'string') {
+    const name = (schema.$ref as string).split('/').pop()!;
+    return schemas[name];
+  }
+  return schema;
+}
+
+function hasOptionalTenantIdsArray(schema: Record<string, unknown> | undefined): boolean {
+  if (!schema || schema.type !== 'object') return false;
+  const props = schema.properties as Record<string, Record<string, unknown>> | undefined;
+  if (!props || !props.tenantIds) return false;
+  const required = (schema.required as string[] | undefined) ?? [];
+  if (required.includes('tenantIds')) return false;
+  const t = props.tenantIds;
+  return t.type === 'array';
+}
+
+function findOpsWithOptionalTenantIds(spec: BundledSpec): string[] {
+  const result = new Set<string>();
+  for (const methods of Object.values(spec.paths)) {
+    for (const op of Object.values(methods)) {
+      const opId = op.operationId;
+      if (!opId) continue;
+      const content = op.requestBody?.content;
+      if (!content) continue;
+      for (const [ct, mt] of Object.entries(content)) {
+        if (!/json/i.test(ct)) continue;
+        const resolved = resolveSchema(mt.schema, spec.components.schemas);
+        if (!resolved) continue;
+        const variants = (resolved.oneOf || resolved.anyOf) as
+          | Record<string, unknown>[]
+          | undefined;
+        if (Array.isArray(variants) && variants.length > 1) {
+          const all = variants
+            .map((v) => resolveSchema(v, spec.components.schemas))
+            .every((rs) => hasOptionalTenantIdsArray(rs));
+          if (all) result.add(opId);
+        } else if (hasOptionalTenantIdsArray(resolved)) {
+          result.add(opId);
+        }
+      }
+    }
+  }
+  return [...result].sort();
+}
+
+describe('default tenantIds (plural) injection — issue #170', () => {
+  it('class-scoped: every operation with optional tenantIds[] body has injection block', () => {
+    const spec = loadBundledSpec();
+    const ops = findOpsWithOptionalTenantIds(spec);
+    // Sanity: activateJobs must be one of them; otherwise the upstream spec changed.
+    expect(ops).toContain('activateJobs');
+
+    const clientSrc = readFileSync(join(__dirname, '..', 'src', 'gen', 'CamundaClient.ts'), 'utf8');
+
+    const missing: string[] = [];
+    for (const opId of ops) {
+      // Find the implementation block for this op (the second overload, with `arg: any`).
+      const implMarker = `${opId}(arg: any`;
+      const start = clientSrc.indexOf(implMarker);
+      expect(
+        start,
+        `implementation for ${opId}(arg: any, …) not found in CamundaClient.ts`
+      ).toBeGreaterThan(-1);
+      // Heuristic end: next "  }" at column 2 followed by newline + a method overload.
+      // Use a generous slice (4 KB) and search within it.
+      const slice = clientSrc.slice(start, start + 4096);
+      const ok =
+        /envelope\.body\.tenantIds\s*=/.test(slice) && /this\._config\.defaultTenantId/.test(slice);
+      if (!ok) missing.push(opId);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('activateJobs injects [defaultTenantId] when tenantIds is omitted', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (/\/jobs\/activation\b/.test(url)) {
+        const raw =
+          typeof init?.body === 'string'
+            ? init.body
+            : input instanceof Request
+              ? await input.text()
+              : '{}';
+        captured = JSON.parse(raw || '{}');
+      }
+      return new Response(JSON.stringify({ jobs: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const client = createCamundaClient({
+      config: {
+        CAMUNDA_REST_ADDRESS: 'http://localhost:8080',
+        CAMUNDA_DEFAULT_TENANT_ID: 'tenant-alpha',
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.activateJobs({
+      type: 'demo-task',
+      timeout: 30_000,
+      maxJobsToActivate: 1,
+    });
+
+    expect(captured).toBeDefined();
+    expect(captured?.tenantIds).toEqual(['tenant-alpha']);
+  });
+
+  it('activateJobs preserves explicit tenantIds when caller provides them', async () => {
+    let captured: Record<string, unknown> | undefined;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (/\/jobs\/activation\b/.test(url)) {
+        const raw =
+          typeof init?.body === 'string'
+            ? init.body
+            : input instanceof Request
+              ? await input.text()
+              : '{}';
+        captured = JSON.parse(raw || '{}');
+      }
+      return new Response(JSON.stringify({ jobs: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const client = createCamundaClient({
+      config: {
+        CAMUNDA_REST_ADDRESS: 'http://localhost:8080',
+        CAMUNDA_DEFAULT_TENANT_ID: 'tenant-alpha',
+      },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.activateJobs({
+      type: 'demo-task',
+      timeout: 30_000,
+      maxJobsToActivate: 1,
+      tenantIds: ['tenant-beta', 'tenant-gamma'],
+    });
+
+    expect(captured?.tenantIds).toEqual(['tenant-beta', 'tenant-gamma']);
+  });
+
+  it('activateJobs falls back to the runtime default tenant sentinel when no env var is set', async () => {
+    // ConfigurationHydrator defaults `defaultTenantId` to the string '<default>'
+    // (see src/runtime/unifiedConfiguration.ts). The injection mirrors the
+    // singular `tenantId` behavior: tenantIds becomes ['<default>'] in this
+    // case rather than being omitted.
+    let captured: Record<string, unknown> | undefined;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (/\/jobs\/activation\b/.test(url)) {
+        const raw =
+          typeof init?.body === 'string'
+            ? init.body
+            : input instanceof Request
+              ? await input.text()
+              : '{}';
+        captured = JSON.parse(raw || '{}');
+      }
+      return new Response(JSON.stringify({ jobs: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const client = createCamundaClient({
+      config: { CAMUNDA_REST_ADDRESS: 'http://localhost:8080' },
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+
+    await client.activateJobs({
+      type: 'demo-task',
+      timeout: 30_000,
+      maxJobsToActivate: 1,
+    });
+
+    expect(captured).toBeDefined();
+    expect(captured?.tenantIds).toEqual(['<default>']);
+  });
+});


### PR DESCRIPTION
Fixes #170.

## Problem

Setting `CAMUNDA_DEFAULT_TENANT_ID` was not enough to make workers poll jobs for that tenant. The class-method generator (`hooks/post/300-generate-class-methods.ts`) injects `config.defaultTenantId` into request bodies that have an optional `tenantId` (singular) property — but operations whose body has an optional `tenantIds: TenantId[]` (plural array) were not covered. `activateJobs` is the only such operation today, so worker polling silently dropped the configured default tenant.

## Fix

Extend the generator to detect operations whose request body has an optional `tenantIds[]` array. The detection reads the bundled spec at hook time and is self-contained in this repo (no `camunda-schema-bundler` release required). For each detected op the generator emits an injection block:

```ts
if (envelope.body && this._config.defaultTenantId !== undefined && this._config.defaultTenantId !== null && (!Array.isArray(envelope.body.tenantIds) || envelope.body.tenantIds.length === 0)) {
  envelope.body.tenantIds = [this._config.defaultTenantId];
  this._log.trace(() => ['tenant.default.inject', { op: 'activateJobs', tenantIds: [this._config.defaultTenantId] }]);
}
```

This mirrors the singular-`tenantId` injection so the runtime contract is consistent across both shapes. Explicit `tenantIds` from the caller are preserved.

## Red/green discipline

Regression coverage in `tests/activate-jobs-default-tenant-ids.test.ts` follows the class-of-defect rule:

- **Class-scoped guard** scans the bundled spec for any operation with an optional `tenantIds[]` body field and asserts each generated impl contains the injection block — guards against the same bug recurring in a future operation, not just `activateJobs`.
- **Behavioral tests** cover injection on omit, preservation of explicit `tenantIds`, and the implicit `'<default>'` fallback when no env var is set (matches the singular-`tenantId` runtime semantics).

Tests were authored failing-first; the structural and "injects on omit" cases failed against the unmodified generator and pass after the hook change.

## Backport

A backport PR will follow targeting `stable/9` per `.github/copilot-instructions.md` ("Backporting generator fixes to `stable/*` branches"). The change is generator-class (hook + regenerated `src/gen/CamundaClient.ts` + test), so it cherry-picks cleanly and stable's release CI will regenerate `src/gen/*` before publishing.