### PR TITLE
fix: getResource is now eventually consistent

### DIFF
--- a/branding/branding-metadata.json
+++ b/branding/branding-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "specHash": "sha256:23c77958ed5c8e6d5bec3a5368ea7cc9aef83d7a745bffdbf618c34ece760409",
+  "specHash": "sha256:6d0560fde009abd591d2bf84c727edc92340880af0b54a90093ed40ebb97f973",
   "generator": {
     "name": "@hey-api/openapi-ts"
   },
@@ -338,28 +338,27 @@
       "name": "DecisionEvaluationInstanceKey",
       "semanticType": "DecisionEvaluationInstanceKey",
       "category": "system-key",
-      "description": "System-generated key for a decision evaluation instance.",
+      "description": "System-generated identifier for a decision evaluation instance. It is composed of the\nparent decision evaluation key and the 1-based index of the evaluated decision within\nthat evaluation, joined by a hyphen (format: `<decisionEvaluationKey>-<index>`).\n",
       "composition": {
-        "schemaKind": "allOf",
-        "refs": [
-          "LongKey"
-        ],
+        "schemaKind": "inline",
+        "refs": [],
         "inlineFragments": 0
       },
       "constraints": {
-        "pattern": "^-?[0-9]+$",
-        "minLength": 1,
-        "maxLength": 25
+        "pattern": "^[0-9]+-[0-9]+$",
+        "minLength": 3,
+        "maxLength": 30,
+        "format": "DecisionEvaluationInstanceKey"
       },
       "examples": [
-        "2251799813684367"
+        "2251799813684367-1"
       ],
       "extensions": {
         "x-semantic-type": "DecisionEvaluationInstanceKey"
       },
       "flags": {
         "semanticKey": true,
-        "includesLongKeyRef": true,
+        "includesLongKeyRef": false,
         "deprecated": false
       },
       "stableId": "decision-evaluation-instance-key",
@@ -1854,6 +1853,29 @@
       }
     },
     {
+      "name": "ElementIdFilterProperty",
+      "kind": "union-wrapper",
+      "description": "ElementId property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "branded-ref",
+          "ref": "ElementIdExactMatch"
+        },
+        {
+          "branchType": "branded-ref",
+          "ref": "AdvancedElementIdFilter"
+        }
+      ],
+      "stableId": "element-id-filter-property",
+      "tsType": "ElementIdExactMatch | AdvancedElementIdFilter",
+      "zod": {
+        "schemaName": "zElementIdFilterProperty"
+      },
+      "source": {
+        "schemaPointer": "#/components/schemas/ElementIdFilterProperty"
+      }
+    },
+    {
       "name": "ElementInstanceKeyFilterProperty",
       "kind": "union-wrapper",
       "description": "ElementInstanceKey property with full advanced search capabilities.",
@@ -2221,6 +2243,29 @@
       }
     },
     {
+      "name": "MessageSubscriptionTypeFilterProperty",
+      "kind": "union-wrapper",
+      "description": "MessageSubscriptionTypeEnum with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "branded-ref",
+          "ref": "MessageSubscriptionTypeExactMatch"
+        },
+        {
+          "branchType": "branded-ref",
+          "ref": "AdvancedMessageSubscriptionTypeFilter"
+        }
+      ],
+      "stableId": "message-subscription-type-filter-property",
+      "tsType": "MessageSubscriptionTypeExactMatch | AdvancedMessageSubscriptionTypeFilter",
+      "zod": {
+        "schemaName": "zMessageSubscriptionTypeFilterProperty"
+      },
+      "source": {
+        "schemaPointer": "#/components/schemas/MessageSubscriptionTypeFilterProperty"
+      }
+    },
+    {
       "name": "OperationTypeFilterProperty",
       "kind": "union-wrapper",
       "description": "AuditLogOperationTypeEnum property with full advanced search capabilities.",
@@ -2241,6 +2286,29 @@
       },
       "source": {
         "schemaPointer": "#/components/schemas/OperationTypeFilterProperty"
+      }
+    },
+    {
+      "name": "ProcessDefinitionIdFilterProperty",
+      "kind": "union-wrapper",
+      "description": "ProcessDefinitionId property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "branded-ref",
+          "ref": "ProcessDefinitionIdExactMatch"
+        },
+        {
+          "branchType": "branded-ref",
+          "ref": "AdvancedProcessDefinitionIdFilter"
+        }
+      ],
+      "stableId": "process-definition-id-filter-property",
+      "tsType": "ProcessDefinitionIdExactMatch | AdvancedProcessDefinitionIdFilter",
+      "zod": {
+        "schemaName": "zProcessDefinitionIdFilterProperty"
+      },
+      "source": {
+        "schemaPointer": "#/components/schemas/ProcessDefinitionIdFilterProperty"
       }
     },
     {
@@ -2620,7 +2688,7 @@
   ],
   "integrity": {
     "totalPrimaryKeys": 34,
-    "totalUnionWrappers": 52,
+    "totalUnionWrappers": 55,
     "implicitCamundaKeys": []
   }
 }

--- a/examples/admin-operations.ts
+++ b/examples/admin-operations.ts
@@ -283,9 +283,12 @@ async function evaluateExpressionExample() {
 async function getResourceExample(resourceKey: ProcessDefinitionKey) {
   const camunda = createCamundaClient();
 
-  const resource = await camunda.getResource({
-    resourceKey,
-  });
+  const resource = await camunda.getResource(
+    {
+      resourceKey,
+    },
+    { consistency: { waitUpToMs: 0 } }
+  );
 
   console.log(`Resource: ${resource.resourceName} (${resource.resourceId})`);
 }
@@ -295,9 +298,12 @@ async function getResourceExample(resourceKey: ProcessDefinitionKey) {
 async function getResourceContentExample(resourceKey: ProcessDefinitionKey) {
   const camunda = createCamundaClient();
 
-  const content = await camunda.getResourceContent({
-    resourceKey,
-  });
+  const content = await camunda.getResourceContent(
+    {
+      resourceKey,
+    },
+    { consistency: { waitUpToMs: 0 } }
+  );
 
   console.log(`Content retrieved (type: ${typeof content})`);
 }

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -186,7 +186,8 @@
           "500": {
             "description": "An internal error occurred while processing the request."
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/audit-logs/{auditLogKey}": {
@@ -239,7 +240,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/authentication/me": {
@@ -276,7 +278,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/authorizations": {
@@ -334,7 +337,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/authorizations/search": {
@@ -378,7 +382,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/authorizations/{authorizationKey}": {
@@ -434,7 +439,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "get": {
         "x-eventually-consistent": true,
@@ -485,7 +491,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -529,7 +536,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/batch-operation-items/search": {
@@ -575,7 +583,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/batch-operations/search": {
@@ -621,7 +630,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/batch-operations/{batchOperationKey}": {
@@ -678,7 +688,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/batch-operations/{batchOperationKey}/cancellation": {
@@ -731,7 +742,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/batch-operations/{batchOperationKey}/resumption": {
@@ -787,7 +799,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/batch-operations/{batchOperationKey}/suspension": {
@@ -843,7 +856,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/clock": {
@@ -899,7 +913,8 @@
               }
             }
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/clock/reset": {
@@ -921,7 +936,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/cluster-variables/global": {
@@ -966,7 +982,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/cluster-variables/global/{name}": {
@@ -1022,7 +1039,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       },
       "put": {
         "operationId": "updateGlobalClusterVariable",
@@ -1086,7 +1104,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       },
       "delete": {
         "operationId": "deleteGlobalClusterVariable",
@@ -1133,7 +1152,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/cluster-variables/search": {
@@ -1188,7 +1208,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/cluster-variables/tenants/{tenantId}": {
@@ -1241,10 +1262,21 @@
           "403": {
             "$ref": "#/paths/~1roles/post/responses/403"
           },
+          "404": {
+            "description": "The tenant with the given ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/cluster-variables/tenants/{tenantId}/{name}": {
@@ -1309,7 +1341,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       },
       "put": {
         "operationId": "updateTenantClusterVariable",
@@ -1382,7 +1415,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       },
       "delete": {
         "operationId": "deleteTenantClusterVariable",
@@ -1438,7 +1472,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/conditionals/evaluation": {
@@ -1529,7 +1564,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/correlated-message-subscriptions/search": {
@@ -1574,7 +1610,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/decision-definitions/evaluation": {
@@ -1642,7 +1679,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/decision-definitions/search": {
@@ -1687,7 +1725,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/decision-definitions/{decisionDefinitionKey}": {
@@ -1743,7 +1782,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/decision-definitions/{decisionDefinitionKey}/xml": {
@@ -1799,7 +1839,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/decision-instances/search": {
@@ -1844,7 +1885,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/decision-instances/{decisionEvaluationInstanceKey}": {
@@ -1900,7 +1942,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/decision-instances/{decisionEvaluationKey}/deletion": {
@@ -1966,7 +2009,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/decision-instances/deletion": {
@@ -2018,7 +2062,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/decision-requirements/search": {
@@ -2063,7 +2108,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/decision-requirements/{decisionRequirementsKey}": {
@@ -2119,7 +2165,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/decision-requirements/{decisionRequirementsKey}/xml": {
@@ -2175,7 +2222,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/deployments": {
@@ -2231,7 +2279,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/documents": {
@@ -2315,7 +2364,8 @@
               }
             }
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/documents/batch": {
@@ -2409,7 +2459,8 @@
           "415": {
             "$ref": "#/paths/~1documents/post/responses/415"
           }
-        }
+        },
+        "x-added-in-version": "8.7"
       }
     },
     "/documents/{documentId}": {
@@ -2475,7 +2526,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -2522,7 +2574,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/documents/{documentId}/links": {
@@ -2587,7 +2640,8 @@
           "400": {
             "$ref": "#/paths/~1clock/put/responses/400"
           }
-        }
+        },
+        "x-added-in-version": "8.7"
       }
     },
     "/element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation": {
@@ -2649,7 +2703,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/element-instances/search": {
@@ -2694,7 +2749,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/element-instances/{elementInstanceKey}": {
@@ -2750,7 +2806,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/element-instances/{elementInstanceKey}/incidents/search": {
@@ -2816,7 +2873,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/element-instances/{elementInstanceKey}/variables": {
@@ -2865,7 +2923,8 @@
           "504": {
             "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/expression/evaluation": {
@@ -2910,7 +2969,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/global-task-listeners": {
@@ -2968,7 +3028,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/global-task-listeners/{id}": {
@@ -3021,7 +3082,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       },
       "put": {
         "x-eventually-consistent": false,
@@ -3088,7 +3150,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -3138,7 +3201,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/global-task-listeners/search": {
@@ -3182,7 +3246,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/groups": {
@@ -3229,7 +3294,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/groups/search": {
@@ -3274,7 +3340,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/groups/{groupId}": {
@@ -3327,7 +3394,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "put": {
         "x-eventually-consistent": false,
@@ -3391,7 +3459,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -3435,7 +3504,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/groups/{groupId}/clients/search": {
@@ -3556,7 +3626,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/groups/{groupId}/clients/{clientId}": {
@@ -3624,7 +3695,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -3680,7 +3752,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/groups/{groupId}/mapping-rules/search": {
@@ -3763,7 +3836,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/groups/{groupId}/mapping-rules/{mappingRuleId}": {
@@ -3831,7 +3905,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -3887,7 +3962,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/groups/{groupId}/roles/search": {
@@ -3970,7 +4046,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/groups/{groupId}/users/search": {
@@ -4090,7 +4167,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/groups/{groupId}/users/{username}": {
@@ -4158,7 +4236,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -4214,7 +4293,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/incidents/search": {
@@ -4259,7 +4339,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/incidents/{incidentKey}": {
@@ -4315,7 +4396,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/incidents/{incidentKey}/resolution": {
@@ -4381,7 +4463,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/incidents/statistics/process-instances-by-definition": {
@@ -4426,7 +4509,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/incidents/statistics/process-instances-by-error": {
@@ -4471,7 +4555,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/jobs/activation": {
@@ -4516,7 +4601,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/jobs/search": {
@@ -4561,7 +4647,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/jobs/{jobKey}": {
@@ -4627,7 +4714,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/jobs/{jobKey}/completion": {
@@ -4693,7 +4781,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/jobs/{jobKey}/error": {
@@ -4759,7 +4848,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/jobs/{jobKey}/failure": {
@@ -4825,7 +4915,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/jobs/statistics/global": {
@@ -4894,7 +4985,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/jobs/statistics/by-types": {
@@ -4939,7 +5031,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/jobs/statistics/by-workers": {
@@ -4984,7 +5077,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/jobs/statistics/time-series": {
@@ -5029,7 +5123,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/jobs/statistics/errors": {
@@ -5074,7 +5169,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/license": {
@@ -5100,7 +5196,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/mapping-rules": {
@@ -5163,7 +5260,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/mapping-rules/search": {
@@ -5224,7 +5322,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/mapping-rules/{mappingRuleId}": {
@@ -5301,7 +5400,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -5345,7 +5445,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "get": {
         "x-eventually-consistent": true,
@@ -5393,7 +5494,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/message-subscriptions/search": {
@@ -5404,7 +5506,7 @@
         ],
         "operationId": "searchMessageSubscriptions",
         "summary": "Search message subscriptions",
-        "description": "Search for message subscriptions based on given criteria.",
+        "description": "Search for message subscriptions based on given criteria.\n\nBy default, both start and intermediate event subscriptions are returned. Use the\n`messageSubscriptionType` filter to restrict results to a single type.\n\n**Version notes:**\n- Start event subscriptions are only captured for deployments made with 8.10 or later.\n- The `messageSubscriptionType` field is only populated for data created\n  with Camunda 8.10 or later. For pre-8.10 data, intermediate event entries have no\n  `messageSubscriptionType` value stored. For convenience, the API returns `PROCESS_EVENT`\n  as a default for such search results, though.\n- Searching for intermediate event subscriptions **including legacy data** can be achieved\n  by filtering for `messageSubscriptionType` not matching `START_EVENT`.\n",
         "requestBody": {
           "required": false,
           "content": {
@@ -5438,7 +5540,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/messages/correlation": {
@@ -5493,7 +5596,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/messages/publication": {
@@ -5535,7 +5639,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/process-definitions/search": {
@@ -5580,7 +5685,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-definitions/statistics/message-subscriptions": {
@@ -5625,7 +5731,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/process-definitions/statistics/process-instances": {
@@ -5670,7 +5777,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/process-definitions/{processDefinitionKey}": {
@@ -5726,7 +5834,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-definitions/{processDefinitionKey}/form": {
@@ -5785,7 +5894,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-definitions/{processDefinitionKey}/statistics/element-instances": {
@@ -5841,7 +5951,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-definitions/{processDefinitionKey}/xml": {
@@ -5907,7 +6018,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-definitions/statistics/process-instances-by-version": {
@@ -5952,7 +6064,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/process-instances": {
@@ -6031,7 +6144,8 @@
               }
             }
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/process-instances/cancellation": {
@@ -6083,7 +6197,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-instances/deletion": {
@@ -6135,7 +6250,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/process-instances/incident-resolution": {
@@ -6187,7 +6303,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-instances/migration": {
@@ -6239,7 +6356,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-instances/modification": {
@@ -6291,7 +6409,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-instances/search": {
@@ -6336,7 +6455,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/process-instances/{processInstanceKey}": {
@@ -6392,7 +6512,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-instances/{processInstanceKey}/call-hierarchy": {
@@ -6451,7 +6572,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-instances/{processInstanceKey}/cancellation": {
@@ -6517,7 +6639,8 @@
           "504": {
             "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/process-instances/{processInstanceKey}/deletion": {
@@ -6593,7 +6716,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/process-instances/{processInstanceKey}/incident-resolution": {
@@ -6649,7 +6773,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/process-instances/{processInstanceKey}/incidents/search": {
@@ -6715,7 +6840,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-instances/{processInstanceKey}/migration": {
@@ -6781,7 +6907,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/process-instances/{processInstanceKey}/modification": {
@@ -6837,7 +6964,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/process-instances/{processInstanceKey}/sequence-flows": {
@@ -6883,7 +7011,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/process-instances/{processInstanceKey}/statistics/element-instances": {
@@ -6929,12 +7058,13 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/resources/{resourceKey}": {
       "get": {
-        "x-eventually-consistent": false,
+        "x-eventually-consistent": true,
         "tags": [
           "Resource"
         ],
@@ -6976,12 +7106,13 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.7"
       }
     },
     "/resources/{resourceKey}/content": {
       "get": {
-        "x-eventually-consistent": false,
+        "x-eventually-consistent": true,
         "tags": [
           "Resource"
         ],
@@ -7003,9 +7134,10 @@
           "200": {
             "description": "The resource content is successfully returned.",
             "content": {
-              "application/json": {
+              "application/octet-stream": {
                 "schema": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "binary"
                 }
               }
             }
@@ -7023,7 +7155,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.7"
       }
     },
     "/resources/{resourceKey}/deletion": {
@@ -7086,7 +7219,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/roles": {
@@ -7154,7 +7288,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/search": {
@@ -7199,7 +7334,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/{roleId}": {
@@ -7252,7 +7388,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "put": {
         "x-eventually-consistent": false,
@@ -7316,7 +7453,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -7360,7 +7498,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/{roleId}/clients/search": {
@@ -7481,7 +7620,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/{roleId}/clients/{clientId}": {
@@ -7549,7 +7689,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -7605,7 +7746,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/{roleId}/groups/search": {
@@ -7671,7 +7813,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/{roleId}/groups/{groupId}": {
@@ -7739,7 +7882,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -7795,7 +7939,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/{roleId}/mapping-rules/search": {
@@ -7878,7 +8023,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/{roleId}/mapping-rules/{mappingRuleId}": {
@@ -7946,7 +8092,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -8002,7 +8149,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/{roleId}/users/search": {
@@ -8122,7 +8270,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/roles/{roleId}/users/{username}": {
@@ -8190,7 +8339,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -8246,7 +8396,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/setup/user": {
@@ -8291,7 +8442,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/signals/broadcast": {
@@ -8343,7 +8495,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/status": {
@@ -8362,7 +8515,8 @@
           "503": {
             "description": "The cluster is DOWN and does not have any partition with a healthy leader."
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/system/usage-metrics": {
@@ -8471,7 +8625,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/system/configuration": {
@@ -8514,7 +8669,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/tenants": {
@@ -8572,7 +8728,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/search": {
@@ -8627,7 +8784,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}": {
@@ -8683,7 +8841,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "put": {
         "x-eventually-consistent": false,
@@ -8747,7 +8906,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -8794,7 +8954,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/clients/search": {
@@ -8894,7 +9055,8 @@
               }
             }
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/clients/{clientId}": {
@@ -8952,7 +9114,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -9008,7 +9171,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/groups/search": {
@@ -9052,7 +9216,8 @@
               }
             }
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/groups/{groupId}": {
@@ -9110,7 +9275,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -9166,7 +9332,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/mapping-rules/search": {
@@ -9227,7 +9394,8 @@
               }
             }
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/mapping-rules/{mappingRuleId}": {
@@ -9285,7 +9453,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -9341,7 +9510,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/roles/search": {
@@ -9402,7 +9572,8 @@
               }
             }
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/roles/{roleId}": {
@@ -9460,7 +9631,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -9516,7 +9688,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/users/search": {
@@ -9615,7 +9788,8 @@
               }
             }
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/tenants/{tenantId}/users/{username}": {
@@ -9673,7 +9847,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -9729,7 +9904,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/topology": {
@@ -9758,7 +9934,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.5"
       }
     },
     "/users": {
@@ -9816,7 +9993,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/users/search": {
@@ -9877,7 +10055,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/users/{username}": {
@@ -9950,7 +10129,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "put": {
         "x-eventually-consistent": false,
@@ -10034,7 +10214,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "delete": {
         "x-eventually-consistent": false,
@@ -10078,7 +10259,8 @@
           "503": {
             "$ref": "#/paths/~1clock/put/responses/503"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/user-tasks/search": {
@@ -10123,7 +10305,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.6"
       }
     },
     "/user-tasks/{userTaskKey}": {
@@ -10179,7 +10362,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       },
       "patch": {
         "x-eventually-consistent": false,
@@ -10264,7 +10448,8 @@
               }
             }
           }
-        }
+        },
+        "x-added-in-version": "8.5"
       }
     },
     "/user-tasks/{userTaskKey}/assignee": {
@@ -10323,7 +10508,8 @@
           "504": {
             "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
-        }
+        },
+        "x-added-in-version": "8.5"
       }
     },
     "/user-tasks/{userTaskKey}/assignment": {
@@ -10392,7 +10578,8 @@
           "504": {
             "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
-        }
+        },
+        "x-added-in-version": "8.5"
       }
     },
     "/user-tasks/{userTaskKey}/audit-logs/search": {
@@ -10442,7 +10629,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.9"
       }
     },
     "/user-tasks/{userTaskKey}/completion": {
@@ -10511,7 +10699,8 @@
           "504": {
             "$ref": "#/paths/~1user-tasks~1{userTaskKey}/patch/responses/504"
           }
-        }
+        },
+        "x-added-in-version": "8.5"
       }
     },
     "/user-tasks/{userTaskKey}/effective-variables/search": {
@@ -10597,7 +10786,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/user-tasks/{userTaskKey}/form": {
@@ -10656,7 +10846,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/user-tasks/{userTaskKey}/variables/search": {
@@ -10759,7 +10950,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/variables/search": {
@@ -10859,7 +11051,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     },
     "/variables/{variableKey}": {
@@ -10915,7 +11108,8 @@
           "500": {
             "$ref": "#/paths/~1clock/put/responses/500"
           }
-        }
+        },
+        "x-added-in-version": "8.8"
       }
     }
   },
@@ -12745,12 +12939,13 @@
             "type": "string"
           },
           "processInstanceKey": {
+            "description": "The process instance key of the processed item. Null for batch-op types whose targets\nare not process instances (e.g. DELETE_DECISION_INSTANCE, DELETE_DECISION_DEFINITION,\nDELETE_PROCESS_DEFINITION).\n",
+            "nullable": true,
             "allOf": [
               {
                 "$ref": "#/components/schemas/ProcessInstanceKey"
               }
-            ],
-            "description": "the process instance key of the processed item."
+            ]
           },
           "rootProcessInstanceKey": {
             "description": "The key of the root process instance. The root process instance is the top-level\nancestor in the process instance hierarchy. This field is only present for data\nbelonging to process instance hierarchies created in version 8.9 or later.\n",
@@ -15754,13 +15949,17 @@
             "description": "The element ID for this element instance.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/ElementId"
+                "$ref": "#/components/schemas/ElementIdFilterProperty"
               }
             ]
           },
           "elementName": {
-            "type": "string",
-            "description": "The element name. This only works for data created with 8.8 and onwards. Instances from prior versions don't contain this data and cannot be found.\n"
+            "description": "The element name. This only works for data created with 8.8 and onwards. Instances from prior versions don't contain this data and cannot be found.\n",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ]
           },
           "hasIncident": {
             "type": "boolean",
@@ -17222,6 +17421,116 @@
         "minLength": 1,
         "maxLength": 256,
         "example": "order-12345"
+      },
+      "ElementIdFilterProperty": {
+        "description": "ElementId property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ElementIdExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedElementIdFilter"
+          }
+        ]
+      },
+      "AdvancedElementIdFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced ElementId filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementId"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ElementId"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ElementId"
+            }
+          },
+          "$notIn": {
+            "description": "Checks if the property matches none of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ElementId"
+            }
+          },
+          "$like": {
+            "$ref": "#/components/schemas/LikeFilter"
+          }
+        }
+      },
+      "ProcessDefinitionIdFilterProperty": {
+        "description": "ProcessDefinitionId property with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ProcessDefinitionIdExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedProcessDefinitionIdFilter"
+          }
+        ]
+      },
+      "AdvancedProcessDefinitionIdFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced ProcessDefinitionId filter.",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessDefinitionId"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProcessDefinitionId"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProcessDefinitionId"
+            }
+          },
+          "$notIn": {
+            "description": "Checks if the property matches none of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProcessDefinitionId"
+            }
+          },
+          "$like": {
+            "$ref": "#/components/schemas/LikeFilter"
+          }
+        }
       },
       "IncidentSearchQuery": {
         "additionalProperties": false,
@@ -19366,6 +19675,7 @@
         "type": "string",
         "enum": [
           "ASSIGNING",
+          "BEFORE_ALL",
           "CANCELING",
           "COMPLETING",
           "CREATING",
@@ -19649,16 +19959,14 @@
         ]
       },
       "DecisionEvaluationInstanceKey": {
-        "description": "System-generated key for a decision evaluation instance.",
+        "description": "System-generated identifier for a decision evaluation instance. It is composed of the\nparent decision evaluation key and the 1-based index of the evaluated decision within\nthat evaluation, joined by a hyphen (format: `<decisionEvaluationKey>-<index>`).\n",
         "format": "DecisionEvaluationInstanceKey",
         "x-semantic-type": "DecisionEvaluationInstanceKey",
-        "example": "2251799813684367",
         "type": "string",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/LongKey"
-          }
-        ]
+        "pattern": "^[0-9]+-[0-9]+$",
+        "minLength": 3,
+        "maxLength": 30,
+        "example": "2251799813684367-1"
       },
       "DecisionEvaluationKey": {
         "allOf": [
@@ -20746,14 +21054,20 @@
           "correlationKey",
           "elementId",
           "elementInstanceKey",
+          "extensionProperties",
+          "inboundConnectorType",
           "lastUpdatedDate",
           "messageName",
           "messageSubscriptionKey",
           "messageSubscriptionState",
+          "messageSubscriptionType",
           "processDefinitionId",
           "processDefinitionKey",
+          "processDefinitionName",
+          "processDefinitionVersion",
           "processInstanceKey",
-          "tenantId"
+          "tenantId",
+          "toolName"
         ],
         "properties": {
           "messageSubscriptionKey": {
@@ -20788,7 +21102,7 @@
               }
             ],
             "nullable": true,
-            "description": "The process instance key associated with this message subscription."
+            "description": "The process instance key associated with this message subscription.\nOnly populated for intermediate event entities.\n"
           },
           "rootProcessInstanceKey": {
             "description": "The key of the root process instance. The root process instance is the top-level\nancestor in the process instance hierarchy. This field is only present for data\nbelonging to process instance hierarchies created in version 8.9 or later.\n",
@@ -20814,7 +21128,7 @@
               }
             ],
             "nullable": true,
-            "description": "The element instance key associated with this message subscription."
+            "description": "The element instance key associated with this message subscription.\nOnly populated for intermediate event entities.\n"
           },
           "messageSubscriptionState": {
             "$ref": "#/components/schemas/MessageSubscriptionStateEnum"
@@ -20833,6 +21147,37 @@
             "nullable": true,
             "description": "The correlation key of the message subscription."
           },
+          "messageSubscriptionType": {
+            "$ref": "#/components/schemas/MessageSubscriptionTypeEnum"
+          },
+          "extensionProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "The `zeebe:properties` extension properties extracted from the BPMN element associated\nwith this subscription. Empty object when no properties are defined.\n"
+          },
+          "processDefinitionName": {
+            "type": "string",
+            "nullable": true,
+            "description": "The name of the process definition associated with this message subscription."
+          },
+          "processDefinitionVersion": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "description": "The version of the process definition associated with this message subscription."
+          },
+          "toolName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Tool name extracted from the `io.camunda.tool:name` zeebe:property.\nNull when the property is absent.\n"
+          },
+          "inboundConnectorType": {
+            "type": "string",
+            "nullable": true,
+            "description": "Inbound connector type extracted from the `inbound.type` zeebe:property.\nNull when the property is absent.\n"
+          },
           "tenantId": {
             "$ref": "#/components/schemas/TenantId"
           }
@@ -20847,14 +21192,19 @@
             "enum": [
               "messageSubscriptionKey",
               "processDefinitionId",
+              "processDefinitionName",
+              "processDefinitionVersion",
               "processInstanceKey",
               "elementId",
               "elementInstanceKey",
               "messageSubscriptionState",
+              "messageSubscriptionType",
               "lastUpdatedDate",
               "messageName",
               "correlationKey",
-              "tenantId"
+              "tenantId",
+              "toolName",
+              "inboundConnectorType"
             ]
           },
           "order": {
@@ -20982,6 +21332,46 @@
               }
             ],
             "description": "The unique external tenant ID."
+          },
+          "messageSubscriptionType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageSubscriptionTypeFilterProperty"
+              }
+            ],
+            "description": "The type of message subscription to filter by. When omitted, both\n`START_EVENT` and `PROCESS_EVENT` are returned. Only available for data\ncreated with Camunda 8.10 or later.\n"
+          },
+          "processDefinitionName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ],
+            "description": "The name of the process definition associated with this message subscription."
+          },
+          "processDefinitionVersion": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IntegerFilterProperty"
+              }
+            ],
+            "description": "The version of the process definition associated with this message subscription."
+          },
+          "toolName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ],
+            "description": "Filter by tool name extracted from the `io.camunda.tool:name` zeebe:property."
+          },
+          "inboundConnectorType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StringFilterProperty"
+              }
+            ],
+            "description": "Filter by inbound connector type extracted from the `inbound.type` zeebe:property."
           }
         }
       },
@@ -21179,6 +21569,14 @@
           "MIGRATED"
         ]
       },
+      "MessageSubscriptionTypeEnum": {
+        "description": "The type of message subscription.\n`START_EVENT` is definition-scoped (process start events). Always has a value; only\ncaptured from Camunda 8.10 onwards.\n`PROCESS_EVENT` is instance-scoped (intermediate catch events). Pre-8.10 entries have\nno value stored; the API returns `PROCESS_EVENT` as a default for those entries.\n",
+        "type": "string",
+        "enum": [
+          "START_EVENT",
+          "PROCESS_EVENT"
+        ]
+      },
       "CorrelatedMessageSubscriptionFilter": {
         "description": "Correlated message subscriptions search filter.",
         "type": "object",
@@ -21278,6 +21676,54 @@
               }
             ],
             "description": "The tenant ID associated with this correlated message subscription."
+          }
+        }
+      },
+      "MessageSubscriptionTypeFilterProperty": {
+        "description": "MessageSubscriptionTypeEnum with full advanced search capabilities.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/MessageSubscriptionTypeExactMatch"
+          },
+          {
+            "$ref": "#/components/schemas/AdvancedMessageSubscriptionTypeFilter"
+          }
+        ]
+      },
+      "AdvancedMessageSubscriptionTypeFilter": {
+        "title": "Advanced filter",
+        "description": "Advanced MessageSubscriptionTypeEnum filter",
+        "type": "object",
+        "properties": {
+          "$eq": {
+            "description": "Checks for equality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageSubscriptionTypeEnum"
+              }
+            ]
+          },
+          "$neq": {
+            "description": "Checks for inequality with the provided value.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MessageSubscriptionTypeEnum"
+              }
+            ]
+          },
+          "$exists": {
+            "description": "Checks if the current property exists.",
+            "type": "boolean"
+          },
+          "$in": {
+            "description": "Checks if the property matches any of the provided values.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageSubscriptionTypeEnum"
+            }
+          },
+          "$like": {
+            "$ref": "#/components/schemas/LikeFilter"
           }
         }
       },
@@ -24669,7 +25115,7 @@
           "processDefinitionId": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ProcessDefinitionId"
+                "$ref": "#/components/schemas/ProcessDefinitionIdFilterProperty"
               }
             ],
             "description": "The ID of the process definition."
@@ -24731,7 +25177,7 @@
           "processDefinitionKey": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ProcessDefinitionKey"
+                "$ref": "#/components/schemas/ProcessDefinitionKeyFilterProperty"
               }
             ],
             "description": "The key of the process definition."
@@ -24739,7 +25185,7 @@
           "processInstanceKey": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ProcessInstanceKey"
+                "$ref": "#/components/schemas/ProcessInstanceKeyFilterProperty"
               }
             ],
             "description": "The key of the process instance."
@@ -25925,6 +26371,26 @@
           }
         ]
       },
+      "ElementIdExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ElementId"
+          }
+        ]
+      },
+      "ProcessDefinitionIdExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ProcessDefinitionId"
+          }
+        ]
+      },
       "IncidentErrorTypeExactMatch": {
         "type": "string",
         "title": "Exact match",
@@ -26093,6 +26559,16 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/DecisionRequirementsKey"
+          }
+        ]
+      },
+      "MessageSubscriptionTypeExactMatch": {
+        "type": "string",
+        "title": "Exact match",
+        "description": "Matches the value exactly.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/MessageSubscriptionTypeEnum"
           }
         ]
       },

--- a/external-spec/bundled/spec-metadata.json
+++ b/external-spec/bundled/spec-metadata.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "specHash": "sha256:23c77958ed5c8e6d5bec3a5368ea7cc9aef83d7a745bffdbf618c34ece760409",
+  "specHash": "sha256:6d0560fde009abd591d2bf84c727edc92340880af0b54a90093ed40ebb97f973",
   "semanticKeys": [
     {
       "name": "AuditLogEntityKey",
@@ -234,28 +234,27 @@
       "name": "DecisionEvaluationInstanceKey",
       "semanticType": "DecisionEvaluationInstanceKey",
       "category": "system-key",
-      "description": "System-generated key for a decision evaluation instance.",
+      "description": "System-generated identifier for a decision evaluation instance. It is composed of the\nparent decision evaluation key and the 1-based index of the evaluated decision within\nthat evaluation, joined by a hyphen (format: `<decisionEvaluationKey>-<index>`).\n",
       "composition": {
-        "schemaKind": "allOf",
-        "refs": [
-          "LongKey"
-        ],
+        "schemaKind": "inline",
+        "refs": [],
         "inlineFragments": 0
       },
       "constraints": {
-        "pattern": "^-?[0-9]+$",
-        "minLength": 1,
-        "maxLength": 25
+        "pattern": "^[0-9]+-[0-9]+$",
+        "minLength": 3,
+        "maxLength": 30,
+        "format": "DecisionEvaluationInstanceKey"
       },
       "examples": [
-        "2251799813684367"
+        "2251799813684367-1"
       ],
       "extensions": {
         "x-semantic-type": "DecisionEvaluationInstanceKey"
       },
       "flags": {
         "semanticKey": true,
-        "includesLongKeyRef": true,
+        "includesLongKeyRef": false,
         "deprecated": false
       },
       "stableId": "decision-evaluation-instance-key"
@@ -1298,6 +1297,22 @@
       "stableId": "deployment-key-filter-property"
     },
     {
+      "name": "ElementIdFilterProperty",
+      "kind": "union-wrapper",
+      "description": "ElementId property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "ElementIdExactMatch"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AdvancedElementIdFilter"
+        }
+      ],
+      "stableId": "element-id-filter-property"
+    },
+    {
       "name": "ElementInstanceKeyFilterProperty",
       "kind": "union-wrapper",
       "description": "ElementInstanceKey property with full advanced search capabilities.",
@@ -1553,6 +1568,22 @@
       "stableId": "message-subscription-state-filter-property"
     },
     {
+      "name": "MessageSubscriptionTypeFilterProperty",
+      "kind": "union-wrapper",
+      "description": "MessageSubscriptionTypeEnum with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "MessageSubscriptionTypeExactMatch"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AdvancedMessageSubscriptionTypeFilter"
+        }
+      ],
+      "stableId": "message-subscription-type-filter-property"
+    },
+    {
       "name": "OperationTypeFilterProperty",
       "kind": "union-wrapper",
       "description": "AuditLogOperationTypeEnum property with full advanced search capabilities.",
@@ -1567,6 +1598,22 @@
         }
       ],
       "stableId": "operation-type-filter-property"
+    },
+    {
+      "name": "ProcessDefinitionIdFilterProperty",
+      "kind": "union-wrapper",
+      "description": "ProcessDefinitionId property with full advanced search capabilities.",
+      "branches": [
+        {
+          "branchType": "ref",
+          "ref": "ProcessDefinitionIdExactMatch"
+        },
+        {
+          "branchType": "ref",
+          "ref": "AdvancedProcessDefinitionIdFilter"
+        }
+      ],
+      "stableId": "process-definition-id-filter-property"
     },
     {
       "name": "ProcessDefinitionKeyFilterProperty",
@@ -2287,6 +2334,22 @@
       "method": "get",
       "tags": [
         "Process instance"
+      ]
+    },
+    {
+      "operationId": "getResource",
+      "path": "/resources/{resourceKey}",
+      "method": "get",
+      "tags": [
+        "Resource"
+      ]
+    },
+    {
+      "operationId": "getResourceContent",
+      "path": "/resources/{resourceKey}/content",
+      "method": "get",
+      "tags": [
+        "Resource"
       ]
     },
     {
@@ -4325,7 +4388,7 @@
         "Message subscription"
       ],
       "summary": "Search message subscriptions",
-      "description": "Search for message subscriptions based on given criteria.",
+      "description": "Search for message subscriptions based on given criteria.\n\nBy default, both start and intermediate event subscriptions are returned. Use the\n`messageSubscriptionType` filter to restrict results to a single type.\n\n**Version notes:**\n- Start event subscriptions are only captured for deployments made with 8.10 or later.\n- The `messageSubscriptionType` field is only populated for data created\n  with Camunda 8.10 or later. For pre-8.10 data, intermediate event entries have no\n  `messageSubscriptionType` value stored. For convenience, the API returns `PROCESS_EVENT`\n  as a default for such search results, though.\n- Searching for intermediate event subscriptions **including legacy data** can be achieved\n  by filtering for `messageSubscriptionType` not matching `START_EVENT`.\n",
       "eventuallyConsistent": true,
       "hasRequestBody": true,
       "requestBodyUnion": false,
@@ -4861,7 +4924,7 @@
       ],
       "summary": "Get resource",
       "description": "Returns a deployed resource.\n:::info\nCurrently, this endpoint only supports RPA resources.\n:::\n",
-      "eventuallyConsistent": false,
+      "eventuallyConsistent": true,
       "hasRequestBody": false,
       "requestBodyUnion": false,
       "bodyOnly": false,
@@ -4881,7 +4944,7 @@
       ],
       "summary": "Get resource content",
       "description": "Returns the content of a deployed resource.\n:::info\nCurrently, this endpoint only supports RPA resources.\n:::\n",
-      "eventuallyConsistent": false,
+      "eventuallyConsistent": true,
       "hasRequestBody": false,
       "requestBodyUnion": false,
       "bodyOnly": false,
@@ -6288,9 +6351,9 @@
   ],
   "integrity": {
     "totalSemanticKeys": 34,
-    "totalUnions": 52,
+    "totalUnions": 55,
     "totalOperations": 183,
-    "totalEventuallyConsistent": 81,
+    "totalEventuallyConsistent": 83,
     "totalDeprecatedEnumSchemas": 2,
     "totalSemanticProviders": 15
   }

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/audit-logs.yaml
@@ -29,6 +29,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           description: An internal error occurred while processing the request.
+      x-added-in-version: "8.9"
 
   /audit-logs/{auditLogKey}:
     get:
@@ -64,6 +65,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/authentication.yaml
@@ -23,6 +23,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/authorizations.yaml
@@ -37,6 +37,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /authorizations/{authorizationKey}:
     put:
@@ -74,6 +75,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     get:
       x-eventually-consistent: true
@@ -108,6 +110,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -138,6 +141,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /authorizations/search:
     post:
@@ -167,6 +171,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/batch-operations.yaml
@@ -37,6 +37,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /batch-operations/search:
     post:
@@ -67,6 +68,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /batch-operations/{batchOperationKey}/cancellation:
     post:
@@ -105,6 +107,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /batch-operations/{batchOperationKey}/suspension:
     post:
@@ -145,6 +148,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /batch-operations/{batchOperationKey}/resumption:
     post:
@@ -185,6 +189,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /batch-operation-items/search:
     post:
@@ -215,6 +220,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 
@@ -492,9 +498,13 @@ components:
           description: Key of the item, e.g. a process instance key.
           type: string
         processInstanceKey:
+          description: |
+            The process instance key of the processed item. Null for batch-op types whose targets
+            are not process instances (e.g. DELETE_DECISION_INSTANCE, DELETE_DECISION_DEFINITION,
+            DELETE_PROCESS_DEFINITION).
+          nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
-          description: the process instance key of the processed item.
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/clock.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /clock/reset:
     post:
@@ -52,6 +53,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
   /cluster-variables/tenants/{tenantId}:
     post:
       operationId: createTenantClusterVariable
@@ -64,8 +65,15 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "403":
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "404":
+          description: The tenant with the given ID was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
   /cluster-variables/search:
     post:
       tags:
@@ -101,6 +109,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
   /cluster-variables/global/{name}:
     get:
       operationId: getGlobalClusterVariable
@@ -137,6 +146,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
     put:
       operationId: updateGlobalClusterVariable
       x-eventually-consistent: false
@@ -180,6 +190,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
     delete:
       operationId: deleteGlobalClusterVariable
       x-eventually-consistent: false
@@ -211,6 +222,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
   /cluster-variables/tenants/{tenantId}/{name}:
     get:
       operationId: getTenantClusterVariable
@@ -253,6 +265,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
     put:
       operationId: updateTenantClusterVariable
       x-eventually-consistent: false
@@ -302,6 +315,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
     delete:
       operationId: deleteTenantClusterVariable
       x-eventually-consistent: false
@@ -339,6 +353,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 components:
   schemas:

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -20,6 +20,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "500":
             $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.5"
 
   /status:
     get:
@@ -34,6 +35,7 @@ paths:
           description: The cluster is UP and has at least one partition with a healthy leader.
         "503":
           description: The cluster is DOWN and does not have any partition with a healthy leader.
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/conditionals.yaml
@@ -65,6 +65,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
 components:
   schemas:

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /decision-definitions/{decisionDefinitionKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /decision-definitions/{decisionDefinitionKey}/xml:
     get:
@@ -108,6 +110,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /decision-definitions/evaluation:
     post:
@@ -157,6 +160,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/decision-instances.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /decision-instances/{decisionEvaluationInstanceKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /decision-instances/{decisionEvaluationKey}/deletion:
     post:
@@ -108,6 +110,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /decision-instances/deletion:
     post:
@@ -146,6 +149,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/decision-requirements.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /decision-requirements/{decisionRequirementsKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /decision-requirements/{decisionRequirementsKey}/xml:
     get:
@@ -108,6 +110,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/deployments.yaml
@@ -41,10 +41,11 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /resources/{resourceKey}:
     get:
-      x-eventually-consistent: false
+      x-eventually-consistent: true
       tags:
         - Resource
       operationId: getResource
@@ -76,10 +77,11 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.7"
 
   /resources/{resourceKey}/content:
     get:
-      x-eventually-consistent: false
+      x-eventually-consistent: true
       tags:
         - Resource
       operationId: getResourceContent
@@ -100,9 +102,10 @@ paths:
         "200":
           description: The resource content is successfully returned.
           content:
-            application/json:
+            application/octet-stream:
               schema:
                 type: string
+                format: binary
         "404":
           description: A resource with the given key was not found.
           content:
@@ -111,6 +114,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.7"
 
   /resources/{resourceKey}/deletion:
     post:
@@ -168,6 +172,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/documents.yaml
@@ -56,6 +56,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "415":
           $ref: 'common-responses.yaml#/components/responses/UnsupportedMediaType'
+      x-added-in-version: "8.6"
 
   /documents/batch:
     post:
@@ -135,6 +136,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "415":
           $ref: 'common-responses.yaml#/components/responses/UnsupportedMediaType'
+      x-added-in-version: "8.7"
 
   /documents/{documentId}:
     get:
@@ -185,6 +187,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
     delete:
       x-eventually-consistent: false
@@ -220,6 +223,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /documents/{documentId}/links:
     post:
@@ -269,6 +273,7 @@ paths:
                 $ref: '#/components/schemas/DocumentLink'
         "400":
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
+      x-added-in-version: "8.7"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/element-instances.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /element-instances/{elementInstanceKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /element-instances/{elementInstanceKey}/variables:
     put:
@@ -111,6 +113,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.6"
 
   /element-instances/{elementInstanceKey}/incidents/search:
     post:
@@ -161,6 +164,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /element-instances/ad-hoc-activities/{adHocSubProcessInstanceKey}/activation:
     post:
@@ -206,6 +210,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 
@@ -298,12 +303,13 @@ components:
         elementId:
           description: The element ID for this element instance.
           allOf:
-            - $ref: "identifiers.yaml#/components/schemas/ElementId"
+            - $ref: 'identifiers.yaml#/components/schemas/ElementIdFilterProperty'
         elementName:
-          type: string
           description: >
             The element name. This only works for data created with 8.8 and onwards.
             Instances from prior versions don't contain this data and cannot be found.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
         hasIncident:
           type: boolean
           description: Shows whether this element instance has an incident related to.

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/expression.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 components:
   schemas:

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/global-listeners.yaml
@@ -38,6 +38,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /global-task-listeners/{id}:
     get:
@@ -73,6 +74,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
     put:
       x-eventually-consistent: false
@@ -117,6 +119,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
     delete:
       x-eventually-consistent: false
@@ -151,6 +154,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /global-task-listeners/search:
     post:
@@ -180,6 +184,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/groups.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/search:
     post:
@@ -60,6 +61,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}:
     get:
@@ -95,6 +97,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     put:
       x-eventually-consistent: false
@@ -137,6 +140,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -167,6 +171,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/users/{username}:
     put:
@@ -214,6 +219,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -254,6 +260,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/users/search:
     post:
@@ -297,6 +304,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/clients/{clientId}:
     put:
@@ -344,6 +352,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -384,6 +393,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/clients/search:
     post:
@@ -427,6 +437,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/mapping-rules/{mappingRuleId}:
     put:
@@ -472,6 +483,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -510,6 +522,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/mapping-rules/search:
     post:
@@ -553,6 +566,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /groups/{groupId}/roles/search:
     post:
@@ -596,6 +610,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -96,3 +96,83 @@ components:
       maxLength: 256
       example: order-12345
 
+
+    ## Filters
+
+    ElementIdFilterProperty:
+      description: ElementId property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/ElementId'
+        - $ref: '#/components/schemas/AdvancedElementIdFilter'
+
+    AdvancedElementIdFilter:
+      title: Advanced filter
+      description: Advanced ElementId filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ElementId'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ElementId'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ElementId'
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ElementId'
+        $like:
+          $ref: 'filters.yaml#/components/schemas/LikeFilter'
+
+    ProcessDefinitionIdFilterProperty:
+      description: ProcessDefinitionId property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/ProcessDefinitionId'
+        - $ref: '#/components/schemas/AdvancedProcessDefinitionIdFilter'
+
+    AdvancedProcessDefinitionIdFilter:
+      title: Advanced filter
+      description: Advanced ProcessDefinitionId filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ProcessDefinitionId'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ProcessDefinitionId'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessDefinitionId'
+        $notIn:
+          description: Checks if the property matches none of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessDefinitionId'
+        $like:
+          $ref: 'filters.yaml#/components/schemas/LikeFilter'

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -31,6 +31,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /incidents/{incidentKey}:
     get:
@@ -69,6 +70,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /incidents/{incidentKey}/resolution:
     post:
@@ -116,6 +118,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /incidents/statistics/process-instances-by-error:
     post:
@@ -150,6 +153,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /incidents/statistics/process-instances-by-definition:
     post:
@@ -185,6 +189,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/job-metrics.yaml
@@ -51,6 +51,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /jobs/statistics/by-types:
     post:
@@ -82,6 +83,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /jobs/statistics/by-workers:
     post:
@@ -113,6 +115,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /jobs/statistics/time-series:
     post:
@@ -146,6 +149,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /jobs/statistics/errors:
     post:
@@ -177,6 +181,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -31,6 +31,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /jobs/search:
     post:
@@ -61,6 +62,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /jobs/{jobKey}/failure:
     post:
@@ -110,6 +112,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /jobs/{jobKey}/error:
     post:
@@ -157,6 +160,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /jobs/{jobKey}/completion:
     post:
@@ -203,6 +207,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /jobs/{jobKey}:
     patch:
@@ -248,6 +253,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 
@@ -1035,6 +1041,7 @@ components:
       type: string
       enum:
         - ASSIGNING
+        - BEFORE_ALL
         - CANCELING
         - COMPLETING
         - CREATING

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/keys.yaml
@@ -102,13 +102,17 @@ components:
         - $ref: '#/components/schemas/LongKey'
 
     DecisionEvaluationInstanceKey:
-      description: System-generated key for a decision evaluation instance.
+      description: |
+        System-generated identifier for a decision evaluation instance. It is composed of the
+        parent decision evaluation key and the 1-based index of the evaluated decision within
+        that evaluation, joined by a hyphen (format: `<decisionEvaluationKey>-<index>`).
       format: DecisionEvaluationInstanceKey
       x-semantic-type: DecisionEvaluationInstanceKey
-      example: "2251799813684367"
       type: string
-      allOf:
-        - $ref: '#/components/schemas/LongKey'
+      pattern: ^[0-9]+-[0-9]+$
+      minLength: 3
+      maxLength: 30
+      example: "2251799813684367-1"
 
     DecisionEvaluationKey:
       allOf:

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/licenses.yaml
@@ -18,6 +18,7 @@ paths:
                 $ref: '#/components/schemas/LicenseResponse'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/mapping-rules.yaml
@@ -40,6 +40,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.8"
   /mapping-rules/{mappingRuleId}:
     put:
       x-eventually-consistent: false
@@ -88,6 +89,7 @@ paths:
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
         "503":
           $ref: "common-responses.yaml#/components/responses/ServiceUnavailable"
+      x-added-in-version: "8.8"
     delete:
       x-eventually-consistent: false
       tags:
@@ -118,6 +120,7 @@ paths:
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
         "503":
           $ref: "common-responses.yaml#/components/responses/ServiceUnavailable"
+      x-added-in-version: "8.8"
     get:
       x-eventually-consistent: true
       tags:
@@ -150,6 +153,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.8"
   /mapping-rules/search:
     post:
       x-eventually-consistent: true
@@ -179,6 +183,7 @@ paths:
           $ref: "common-responses.yaml#/components/responses/Forbidden"
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/messages.yaml
@@ -33,6 +33,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /messages/correlation:
     post:
@@ -73,6 +74,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /message-subscriptions/search:
     post:
@@ -81,7 +83,20 @@ paths:
         - Message subscription
       operationId: searchMessageSubscriptions
       summary: Search message subscriptions
-      description: Search for message subscriptions based on given criteria.
+      description: |
+        Search for message subscriptions based on given criteria.
+
+        By default, both start and intermediate event subscriptions are returned. Use the
+        `messageSubscriptionType` filter to restrict results to a single type.
+
+        **Version notes:**
+        - Start event subscriptions are only captured for deployments made with 8.10 or later.
+        - The `messageSubscriptionType` field is only populated for data created
+          with Camunda 8.10 or later. For pre-8.10 data, intermediate event entries have no
+          `messageSubscriptionType` value stored. For convenience, the API returns `PROCESS_EVENT`
+          as a default for such search results, though.
+        - Searching for intermediate event subscriptions **including legacy data** can be achieved
+          by filtering for `messageSubscriptionType` not matching `START_EVENT`.
       requestBody:
         required: false
         content:
@@ -103,6 +118,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /correlated-message-subscriptions/search:
     post:
@@ -133,6 +149,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 
@@ -254,14 +271,20 @@ components:
         - correlationKey
         - elementId
         - elementInstanceKey
+        - extensionProperties
+        - inboundConnectorType
         - lastUpdatedDate
         - messageName
         - messageSubscriptionKey
         - messageSubscriptionState
+        - messageSubscriptionType
         - processDefinitionId
         - processDefinitionKey
+        - processDefinitionName
+        - processDefinitionVersion
         - processInstanceKey
         - tenantId
+        - toolName
       properties:
         messageSubscriptionKey:
           allOf:
@@ -280,7 +303,9 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
           nullable: true
-          description: The process instance key associated with this message subscription.
+          description: |
+            The process instance key associated with this message subscription.
+            Only populated for intermediate event entities.
         rootProcessInstanceKey:
           description: |
             The key of the root process instance. The root process instance is the top-level
@@ -297,7 +322,9 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ElementInstanceKey'
           nullable: true
-          description: The element instance key associated with this message subscription.
+          description: |
+            The element instance key associated with this message subscription.
+            Only populated for intermediate event entities.
         messageSubscriptionState:
           $ref: '#/components/schemas/MessageSubscriptionStateEnum'
         lastUpdatedDate:
@@ -311,6 +338,36 @@ components:
           type: string
           nullable: true
           description: The correlation key of the message subscription.
+        messageSubscriptionType:
+          $ref: '#/components/schemas/MessageSubscriptionTypeEnum'
+        extensionProperties:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            The `zeebe:properties` extension properties extracted from the BPMN element associated
+            with this subscription. Empty object when no properties are defined.
+        processDefinitionName:
+          type: string
+          nullable: true
+          description: The name of the process definition associated with this message subscription.
+        processDefinitionVersion:
+          type: integer
+          format: int32
+          nullable: true
+          description: The version of the process definition associated with this message subscription.
+        toolName:
+          type: string
+          nullable: true
+          description: |
+            Tool name extracted from the `io.camunda.tool:name` zeebe:property.
+            Null when the property is absent.
+        inboundConnectorType:
+          type: string
+          nullable: true
+          description: |
+            Inbound connector type extracted from the `inbound.type` zeebe:property.
+            Null when the property is absent.
         tenantId:
           $ref: 'identifiers.yaml#/components/schemas/TenantId'
 
@@ -323,14 +380,19 @@ components:
           enum:
             - messageSubscriptionKey
             - processDefinitionId
+            - processDefinitionName
+            - processDefinitionVersion
             - processInstanceKey
             - elementId
             - elementInstanceKey
             - messageSubscriptionState
+            - messageSubscriptionType
             - lastUpdatedDate
             - messageName
             - correlationKey
             - tenantId
+            - toolName
+            - inboundConnectorType
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:
@@ -400,6 +462,29 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The unique external tenant ID.
+        messageSubscriptionType:
+          allOf:
+            - $ref: '#/components/schemas/MessageSubscriptionTypeFilterProperty'
+          description: |
+            The type of message subscription to filter by. When omitted, both
+            `START_EVENT` and `PROCESS_EVENT` are returned. Only available for data
+            created with Camunda 8.10 or later.
+        processDefinitionName:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: The name of the process definition associated with this message subscription.
+        processDefinitionVersion:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
+          description: The version of the process definition associated with this message subscription.
+        toolName:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: Filter by tool name extracted from the `io.camunda.tool:name` zeebe:property.
+        inboundConnectorType:
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+          description: Filter by inbound connector type extracted from the `inbound.type` zeebe:property.
 
     CorrelatedMessageSubscriptionSearchQueryResult:
       required:
@@ -540,6 +625,18 @@ components:
         - DELETED
         - MIGRATED
 
+    MessageSubscriptionTypeEnum:
+      description: |
+        The type of message subscription.
+        `START_EVENT` is definition-scoped (process start events). Always has a value; only
+        captured from Camunda 8.10 onwards.
+        `PROCESS_EVENT` is instance-scoped (intermediate catch events). Pre-8.10 entries have
+        no value stored; the API returns `PROCESS_EVENT` as a default for those entries.
+      type: string
+      enum:
+        - START_EVENT
+        - PROCESS_EVENT
+
     ## Filters
 
     CorrelatedMessageSubscriptionFilter:
@@ -594,6 +691,40 @@ components:
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
           description: The tenant ID associated with this correlated message subscription.
+
+    MessageSubscriptionTypeFilterProperty:
+      description: MessageSubscriptionTypeEnum with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/MessageSubscriptionTypeEnum"
+        - $ref: '#/components/schemas/AdvancedMessageSubscriptionTypeFilter'
+
+    AdvancedMessageSubscriptionTypeFilter:
+      title: Advanced filter
+      description: Advanced MessageSubscriptionTypeEnum filter
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/MessageSubscriptionTypeEnum"
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: "#/components/schemas/MessageSubscriptionTypeEnum"
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageSubscriptionTypeEnum"
+        $like:
+          $ref: "filters.yaml#/components/schemas/LikeFilter"
 
     MessageSubscriptionStateFilterProperty:
       description: MessageSubscriptionStateEnum with full advanced search capabilities.

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -30,6 +30,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/{processDefinitionKey}:
     get:
@@ -71,6 +72,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/{processDefinitionKey}/xml:
     get:
@@ -117,6 +119,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/{processDefinitionKey}/form:
     get:
@@ -158,6 +161,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/{processDefinitionKey}/statistics/element-instances:
     post:
@@ -195,6 +199,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-definitions/statistics/message-subscriptions:
     post:
@@ -226,6 +231,7 @@ paths:
           $ref: "common-responses.yaml#/components/responses/Forbidden"
         "500":
           $ref: "common-responses.yaml#/components/responses/InternalServerError"
+      x-added-in-version: "8.9"
 
   /process-definitions/statistics/process-instances:
     post:
@@ -257,6 +263,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /process-definitions/statistics/process-instances-by-version:
     post:
@@ -289,6 +296,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -66,6 +66,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+      x-added-in-version: "8.6"
 
   /process-instances/{processInstanceKey}:
     get:
@@ -103,6 +104,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/{processInstanceKey}/sequence-flows:
     get:
@@ -134,6 +136,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/{processInstanceKey}/statistics/element-instances:
     get:
@@ -165,6 +168,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/search:
     post:
@@ -195,6 +199,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /process-instances/{processInstanceKey}/incidents/search:
     post:
@@ -244,6 +249,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/{processInstanceKey}/incident-resolution:
     post:
@@ -281,6 +287,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /process-instances/{processInstanceKey}/cancellation:
     post:
@@ -325,6 +332,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.6"
 
   /process-instances/cancellation:
     post:
@@ -365,6 +373,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/incident-resolution:
     post:
@@ -405,6 +414,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/migration:
     post:
@@ -445,6 +455,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/modification:
     post:
@@ -487,6 +498,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /process-instances/{processInstanceKey}/deletion:
     post:
@@ -532,6 +544,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.9"
 
   /process-instances/deletion:
     post:
@@ -571,6 +584,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
   /process-instances/{processInstanceKey}/migration:
     post:
@@ -623,6 +637,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /process-instances/{processInstanceKey}/modification:
     post:
@@ -666,6 +681,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
   /process-instances/{processInstanceKey}/call-hierarchy:
     get:
@@ -705,6 +721,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/roles.yaml
@@ -31,6 +31,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/search:
     post:
@@ -61,6 +62,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}:
     get:
@@ -96,6 +98,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     put:
       x-eventually-consistent: false
@@ -138,6 +141,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -168,6 +172,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/users/{username}:
     put:
@@ -213,6 +218,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -251,6 +257,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/users/search:
     post:
@@ -294,6 +301,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/clients/{clientId}:
     put:
@@ -339,6 +347,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -377,6 +386,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/clients/search:
     post:
@@ -420,6 +430,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/groups/{groupId}:
     put:
@@ -465,6 +476,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -503,6 +515,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/groups/search:
     post:
@@ -546,6 +559,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/mapping-rules/{mappingRuleId}:
     put:
@@ -591,6 +605,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -629,6 +644,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /roles/{roleId}/mapping-rules/search:
     post:
@@ -672,6 +688,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/setup.yaml
@@ -30,3 +30,4 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/signals.yaml
@@ -34,6 +34,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.6"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/system.yaml
@@ -77,6 +77,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
   /system/configuration:
     get:
       tags:
@@ -111,6 +112,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Unauthorized'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 
 ## Schema definitions

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/tenants.yaml
@@ -38,6 +38,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/search:
     post:
@@ -74,6 +75,7 @@ paths:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}:
     get:
@@ -111,6 +113,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     put:
       x-eventually-consistent: false
@@ -153,6 +156,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -185,6 +189,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/users/{username}:
     put:
@@ -224,6 +229,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -264,6 +270,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/users/search:
     post:
@@ -293,6 +300,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantUserSearchResult'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/clients/{clientId}:
     put:
@@ -334,6 +342,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -374,6 +383,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/clients/search:
     post:
@@ -403,6 +413,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantClientSearchResult'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/groups/{groupId}:
     put:
@@ -444,6 +455,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -484,6 +496,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/groups/search:
     post:
@@ -513,6 +526,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantGroupSearchResult'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/roles/search:
     post:
@@ -542,6 +556,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantRoleSearchResult'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/roles/{roleId}:
     put:
@@ -583,6 +598,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -624,6 +640,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/mapping-rules/{mappingRuleId}:
     put:
@@ -663,6 +680,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -701,6 +719,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /tenants/{tenantId}/mapping-rules/search:
     post:
@@ -730,6 +749,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantMappingRuleSearchResult'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -51,6 +51,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.5"
 
   /user-tasks/{userTaskKey}/assignment:
     post:
@@ -103,6 +104,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.5"
 
   /user-tasks/{userTaskKey}:
     get:
@@ -140,6 +142,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     patch:
       x-eventually-consistent: false
@@ -190,6 +193,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.5"
 
   /user-tasks/{userTaskKey}/form:
     get:
@@ -231,6 +235,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /user-tasks/{userTaskKey}/assignee:
     delete:
@@ -277,6 +282,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
         "504":
           $ref: 'common-responses.yaml#/components/responses/GatewayTimeoutTaskListenerBlocking'
+      x-added-in-version: "8.5"
 
   /user-tasks/search:
     post:
@@ -307,6 +313,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.6"
 
   /user-tasks/{userTaskKey}/variables/search:
     post:
@@ -353,6 +360,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /user-tasks/{userTaskKey}/effective-variables/search:
     post:
@@ -398,6 +406,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /user-tasks/{userTaskKey}/audit-logs/search:
     post:
@@ -431,6 +440,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InvalidData'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.9"
 
 ## Schema definitions
 
@@ -511,7 +521,7 @@ components:
           description: Tenant ID of this user task.
         processDefinitionId:
           allOf:
-            - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
+            - $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionIdFilterProperty'
           description: The ID of the process definition.
         creationDate:
           allOf:
@@ -545,11 +555,11 @@ components:
           description: The key for this user task.
         processDefinitionKey:
           allOf:
-            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
+            - $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKeyFilterProperty'
           description: The key of the process definition.
         processInstanceKey:
           allOf:
-            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+            - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKeyFilterProperty'
           description: The key of the process instance.
         elementInstanceKey:
           allOf:

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/users.yaml
@@ -38,6 +38,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
   /users/search:
     post:
@@ -67,6 +68,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /users/{username}:
     get:
@@ -102,6 +104,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
     put:
       x-eventually-consistent: false
@@ -144,6 +147,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
     delete:
       x-eventually-consistent: false
@@ -174,6 +178,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/external-spec/upstream/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -46,6 +46,7 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/Forbidden'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
   /variables/{variableKey}:
     get:
@@ -88,6 +89,7 @@ paths:
                 $ref: "problem-detail.yaml#/components/schemas/ProblemDetail"
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.8"
 
 ## Schema definitions
 

--- a/scripts/check-method-example-completeness.cjs
+++ b/scripts/check-method-example-completeness.cjs
@@ -72,7 +72,7 @@ const templateMethods = new Set();
 
 // Regex: match method declarations at 2-space indent (class body level).
 // Patterns:   async methodName(   |   methodName(   |   get propName()   |   methodName<T>(
-const methodDeclRe = /^  (?:async\s+)?(?:get\s+)?(\w+)\s*[<(]/gm;
+const methodDeclRe = /^ {2}(?:async\s+)?(?:get\s+)?(\w+)\s*[<(]/gm;
 let tm;
 while ((tm = methodDeclRe.exec(fullTemplateSection)) !== null) {
   const name = tm[1];
@@ -173,7 +173,6 @@ for (const method of allMethods) {
   }
   if (operationMap[method]) {
     methodsWithExamples.add(method);
-    continue;
   }
 }
 

--- a/src/facade/operations.gen.ts
+++ b/src/facade/operations.gen.ts
@@ -1647,6 +1647,19 @@ type _searchMessageSubscriptions_Body = SearchMessageSubscriptionsData extends {
  * Search message subscriptions
  *
  * Search for message subscriptions based on given criteria.
+ *
+ * By default, both start and intermediate event subscriptions are returned. Use the
+ * `messageSubscriptionType` filter to restrict results to a single type.
+ *
+ * **Version notes:**
+ * - Start event subscriptions are only captured for deployments made with 8.10 or later.
+ * - The `messageSubscriptionType` field is only populated for data created
+ * with Camunda 8.10 or later. For pre-8.10 data, intermediate event entries have no
+ * `messageSubscriptionType` value stored. For convenience, the API returns `PROCESS_EVENT`
+ * as a default for such search results, though.
+ * - Searching for intermediate event subscriptions **including legacy data** can be achieved
+ * by filtering for `messageSubscriptionType` not matching `START_EVENT`.
+ *
   *
  * @example Search message subscriptions
  * ```ts
@@ -3543,16 +3556,20 @@ export function getProcessInstanceStatistics(options: Parameters<typeof _getProc
  * 
  *   const resource = await camunda.getResource({
  *     resourceKey,
- *   });
+ *   }, { consistency: { waitUpToMs: 0 } });
  * 
  *   console.log(`Resource: ${resource.resourceName} (${resource.resourceId})`);
  * }
  * ```
  * @operationId getResource
  * @tags Resource
+  *
+ * Consistency: Eventually consistent – may return 404/empty until propagation.
  */
-export function getResource(options?: Parameters<typeof _getResource>[0]): CancelablePromise<_DataOf<typeof _getResource>> {
-  return toCancelable(signal => _getResource({ ...(options||{}), signal } as any).then((r:any)=> (r as any).data));
+export function getResource(options: Parameters<typeof _getResource>[0] | undefined, ec: { consistency: ConsistencyOptions<_DataOf<typeof _getResource>> }): CancelablePromise<_DataOf<typeof _getResource>> {
+  if (!ec || !ec.consistency) throw new Error('Missing consistency options (mandatory for eventually consistent endpoint)');
+  const invoke = () => toCancelable(signal => _getResource({ ...(options||{}), signal } as any).then((r:any)=> (r as any).data));
+  return eventualPoll('getResource', true, invoke, ec.consistency);
 }
 
 /**
@@ -3571,16 +3588,20 @@ export function getResource(options?: Parameters<typeof _getResource>[0]): Cance
  * 
  *   const content = await camunda.getResourceContent({
  *     resourceKey,
- *   });
+ *   }, {consistency: { waitUpToMs: 0 }});
  * 
  *   console.log(`Content retrieved (type: ${typeof content})`);
  * }
  * ```
  * @operationId getResourceContent
  * @tags Resource
+  *
+ * Consistency: Eventually consistent – may return 404/empty until propagation.
  */
-export function getResourceContent(options?: Parameters<typeof _getResourceContent>[0]): CancelablePromise<_DataOf<typeof _getResourceContent>> {
-  return toCancelable(signal => _getResourceContent({ ...(options||{}), signal } as any).then((r:any)=> (r as any).data));
+export function getResourceContent(options: Parameters<typeof _getResourceContent>[0] | undefined, ec: { consistency: ConsistencyOptions<_DataOf<typeof _getResourceContent>> }): CancelablePromise<_DataOf<typeof _getResourceContent>> {
+  if (!ec || !ec.consistency) throw new Error('Missing consistency options (mandatory for eventually consistent endpoint)');
+  const invoke = () => toCancelable(signal => _getResourceContent({ ...(options||{}), signal } as any).then((r:any)=> (r as any).data));
+  return eventualPoll('getResourceContent', true, invoke, ec.consistency);
 }
 
 /**
@@ -5391,4 +5412,4 @@ export function updateUserTask(options?: Parameters<typeof _updateUserTask>[0]):
   return toCancelable(signal => _updateUserTask({ ...(options||{}), signal } as any).then((r:any)=> (r as any).data));
 }
 
-// SENTINEL_FACADE_PREWRITE hash=7859385dc415da57 totalWrappers=183 elements=1162 physicalLines=2845
+// SENTINEL_FACADE_PREWRITE hash=756e092b0203b457 totalWrappers=183 elements=1166 physicalLines=2866

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -516,9 +516,19 @@ export type getProcessInstanceStatisticsByErrorConsistency = {
 type getResourceOptions = Parameters<typeof Sdk.getResource>[0];
 type getResourcePathParam_resourceKey = (NonNullable<getResourceOptions> extends { path: { resourceKey: infer P } } ? P : any);
 export type getResourceInput = { resourceKey: getResourcePathParam_resourceKey };
+/** Management of eventual consistency **/
+export type getResourceConsistency = { 
+/** Management of eventual consistency tolerance. Set waitUpToMs to 0 to ignore eventual consistency. pollInterval is 500ms by default. */
+    consistency: ConsistencyOptions<_DataOf<typeof Sdk.getResource>> 
+};
 type getResourceContentOptions = Parameters<typeof Sdk.getResourceContent>[0];
 type getResourceContentPathParam_resourceKey = (NonNullable<getResourceContentOptions> extends { path: { resourceKey: infer P } } ? P : any);
 export type getResourceContentInput = { resourceKey: getResourceContentPathParam_resourceKey };
+/** Management of eventual consistency **/
+export type getResourceContentConsistency = { 
+/** Management of eventual consistency tolerance. Set waitUpToMs to 0 to ignore eventual consistency. pollInterval is 500ms by default. */
+    consistency: ConsistencyOptions<_DataOf<typeof Sdk.getResourceContent>> 
+};
 type getRoleOptions = Parameters<typeof Sdk.getRole>[0];
 type getRolePathParam_roleId = (NonNullable<getRoleOptions> extends { path: { roleId: infer P } } ? P : any);
 export type getRoleInput = { roleId: getRolePathParam_roleId };
@@ -8628,16 +8638,19 @@ export class CamundaClient {
    * 
    *   const resource = await camunda.getResource({
    *     resourceKey,
-   *   });
+   *   }, { consistency: { waitUpToMs: 0 } });
    * 
    *   console.log(`Resource: ${resource.resourceName} (${resource.resourceId})`);
    * }
    * ```
    * @operationId getResource
    * @tags Resource
+   * @consistency eventual - this endpoint is backed by data that is eventually consistent with the system state.
    */
-  getResource(input: getResourceInput, options?: OperationOptions): CancelablePromise<_DataOf<typeof Sdk.getResource>>;
-  getResource(arg: any, options?: OperationOptions): CancelablePromise<any> {
+  getResource(input: getResourceInput, /** Management of eventual consistency **/ consistencyManagement: getResourceConsistency, options?: OperationOptions): CancelablePromise<_DataOf<typeof Sdk.getResource>>;
+  getResource(arg: any, /** Management of eventual consistency **/ consistencyManagement: getResourceConsistency, options?: OperationOptions): CancelablePromise<any> {
+    if (!consistencyManagement) throw new Error("Missing consistencyManagement parameter for eventually consistent endpoint");
+    const useConsistency = consistencyManagement.consistency;
     return toCancelable(async signal => {
       const { resourceKey } = arg || {};
       let envelope: any = {};
@@ -8684,7 +8697,9 @@ export class CamundaClient {
           throw e;
         }
       };
-      return this._invokeWithRetry(() => call(), { opId: 'getResource', exempt: false, retryOverride: options?.retry });
+      const invoke = () => toCancelable(()=>call());
+      if (useConsistency) return eventualPoll('getResource', true, invoke, { ...useConsistency, logger: this._log });
+      return invoke();
     });
   }
 
@@ -8704,16 +8719,19 @@ export class CamundaClient {
    * 
    *   const content = await camunda.getResourceContent({
    *     resourceKey,
-   *   });
+   *   }, {consistency: { waitUpToMs: 0 }});
    * 
    *   console.log(`Content retrieved (type: ${typeof content})`);
    * }
    * ```
    * @operationId getResourceContent
    * @tags Resource
+   * @consistency eventual - this endpoint is backed by data that is eventually consistent with the system state.
    */
-  getResourceContent(input: getResourceContentInput, options?: OperationOptions): CancelablePromise<_DataOf<typeof Sdk.getResourceContent>>;
-  getResourceContent(arg: any, options?: OperationOptions): CancelablePromise<any> {
+  getResourceContent(input: getResourceContentInput, /** Management of eventual consistency **/ consistencyManagement: getResourceContentConsistency, options?: OperationOptions): CancelablePromise<_DataOf<typeof Sdk.getResourceContent>>;
+  getResourceContent(arg: any, /** Management of eventual consistency **/ consistencyManagement: getResourceContentConsistency, options?: OperationOptions): CancelablePromise<any> {
+    if (!consistencyManagement) throw new Error("Missing consistencyManagement parameter for eventually consistent endpoint");
+    const useConsistency = consistencyManagement.consistency;
     return toCancelable(async signal => {
       const { resourceKey } = arg || {};
       let envelope: any = {};
@@ -8760,7 +8778,9 @@ export class CamundaClient {
           throw e;
         }
       };
-      return this._invokeWithRetry(() => call(), { opId: 'getResourceContent', exempt: false, retryOverride: options?.retry });
+      const invoke = () => toCancelable(()=>call());
+      if (useConsistency) return eventualPoll('getResourceContent', true, invoke, { ...useConsistency, logger: this._log });
+      return invoke();
     });
   }
 
@@ -12530,6 +12550,19 @@ export class CamundaClient {
    * Search message subscriptions
    *
    * Search for message subscriptions based on given criteria.
+   *
+   * By default, both start and intermediate event subscriptions are returned. Use the
+   * `messageSubscriptionType` filter to restrict results to a single type.
+   *
+   * **Version notes:**
+   * - Start event subscriptions are only captured for deployments made with 8.10 or later.
+   * - The `messageSubscriptionType` field is only populated for data created
+   * with Camunda 8.10 or later. For pre-8.10 data, intermediate event entries have no
+   * `messageSubscriptionType` value stored. For convenience, the API returns `PROCESS_EVENT`
+   * as a default for such search results, though.
+   * - Searching for intermediate event subscriptions **including legacy data** can be achieved
+   * by filtering for `messageSubscriptionType` not matching `START_EVENT`.
+   *
     *
    * @example Search message subscriptions
    * ```ts

--- a/src/gen/sdk.gen.ts
+++ b/src/gen/sdk.gen.ts
@@ -1661,6 +1661,19 @@ export const updateMappingRule = <ThrowOnError extends boolean = true>(options: 
  * Search message subscriptions
  *
  * Search for message subscriptions based on given criteria.
+ *
+ * By default, both start and intermediate event subscriptions are returned. Use the
+ * `messageSubscriptionType` filter to restrict results to a single type.
+ *
+ * **Version notes:**
+ * - Start event subscriptions are only captured for deployments made with 8.10 or later.
+ * - The `messageSubscriptionType` field is only populated for data created
+ * with Camunda 8.10 or later. For pre-8.10 data, intermediate event entries have no
+ * `messageSubscriptionType` value stored. For convenience, the API returns `PROCESS_EVENT`
+ * as a default for such search results, though.
+ * - Searching for intermediate event subscriptions **including legacy data** can be achieved
+ * by filtering for `messageSubscriptionType` not matching `START_EVENT`.
+ *
  */
 export const searchMessageSubscriptions = <ThrowOnError extends boolean = true>(options?: Options<SearchMessageSubscriptionsData, ThrowOnError>) => {
     return (options?.client ?? client).post<SearchMessageSubscriptionsResponses, SearchMessageSubscriptionsErrors, ThrowOnError>({

--- a/src/gen/specHash.ts
+++ b/src/gen/specHash.ts
@@ -1,3 +1,3 @@
 // Auto-generated — do not edit.
 // SHA-256 digest of the OpenAPI spec this SDK was generated from.
-export const SPEC_HASH = "sha256:23c77958ed5c8e6d5bec3a5368ea7cc9aef83d7a745bffdbf618c34ece760409" as const;
+export const SPEC_HASH = "sha256:6d0560fde009abd591d2bf84c727edc92340880af0b54a90093ed40ebb97f973" as const;

--- a/src/gen/types.gen.ts
+++ b/src/gen/types.gen.ts
@@ -1005,9 +1005,12 @@ export type BatchOperationItemResponse = {
      */
     itemKey: string;
     /**
-     * the process instance key of the processed item.
+     * The process instance key of the processed item. Null for batch-op types whose targets
+     * are not process instances (e.g. DELETE_DECISION_INSTANCE, DELETE_DECISION_DEFINITION,
+     * DELETE_PROCESS_DEFINITION).
+     *
      */
-    processInstanceKey: ProcessInstanceKey;
+    processInstanceKey: ProcessInstanceKey | null;
     /**
      * The key of the root process instance. The root process instance is the top-level
      * ancestor in the process instance hierarchy. This field is only present for data
@@ -2708,12 +2711,12 @@ export type ElementInstanceFilter = {
     /**
      * The element ID for this element instance.
      */
-    elementId?: ElementId;
+    elementId?: ElementIdFilterProperty;
     /**
      * The element name. This only works for data created with 8.8 and onwards. Instances from prior versions don't contain this data and cannot be found.
      *
      */
-    elementName?: string;
+    elementName?: StringFilterProperty;
     /**
      * Shows whether this element instance has an incident related to.
      */
@@ -3524,6 +3527,74 @@ export type TagSet = Array<Tag> & { readonly length: 0 | 1 | 2 | 3 | 4 | 5 | 6 |
  *
  */
 export type BusinessId = CamundaKey<'BusinessId'>;
+
+/**
+ * ElementId property with full advanced search capabilities.
+ */
+export type ElementIdFilterProperty = ElementIdExactMatch | AdvancedElementIdFilter;
+
+/**
+ * Advanced filter
+ *
+ * Advanced ElementId filter.
+ */
+export type AdvancedElementIdFilter = {
+    /**
+     * Checks for equality with the provided value.
+     */
+    $eq?: ElementId;
+    /**
+     * Checks for inequality with the provided value.
+     */
+    $neq?: ElementId;
+    /**
+     * Checks if the current property exists.
+     */
+    $exists?: boolean;
+    /**
+     * Checks if the property matches any of the provided values.
+     */
+    $in?: Array<ElementId>;
+    /**
+     * Checks if the property matches none of the provided values.
+     */
+    $notIn?: Array<ElementId>;
+    $like?: LikeFilter;
+};
+
+/**
+ * ProcessDefinitionId property with full advanced search capabilities.
+ */
+export type ProcessDefinitionIdFilterProperty = ProcessDefinitionIdExactMatch | AdvancedProcessDefinitionIdFilter;
+
+/**
+ * Advanced filter
+ *
+ * Advanced ProcessDefinitionId filter.
+ */
+export type AdvancedProcessDefinitionIdFilter = {
+    /**
+     * Checks for equality with the provided value.
+     */
+    $eq?: ProcessDefinitionId;
+    /**
+     * Checks for inequality with the provided value.
+     */
+    $neq?: ProcessDefinitionId;
+    /**
+     * Checks if the current property exists.
+     */
+    $exists?: boolean;
+    /**
+     * Checks if the property matches any of the provided values.
+     */
+    $in?: Array<ProcessDefinitionId>;
+    /**
+     * Checks if the property matches none of the provided values.
+     */
+    $notIn?: Array<ProcessDefinitionId>;
+    $like?: LikeFilter;
+};
 
 export type IncidentSearchQuery = SearchQueryRequest & {
     /**
@@ -4762,6 +4833,7 @@ export type JobKindEnum = (typeof JobKindEnum)[keyof typeof JobKindEnum];
  */
 export const JobListenerEventTypeEnum = {
   ASSIGNING: 'ASSIGNING',
+  BEFORE_ALL: 'BEFORE_ALL',
   CANCELING: 'CANCELING',
   COMPLETING: 'COMPLETING',
   CREATING: 'CREATING',
@@ -4919,7 +4991,10 @@ export type JobKey = CamundaKey<'JobKey'>;
 export type DecisionDefinitionKey = CamundaKey<'DecisionDefinitionKey'>;
 
 /**
- * System-generated key for a decision evaluation instance.
+ * System-generated identifier for a decision evaluation instance. It is composed of the
+ * parent decision evaluation key and the 1-based index of the evaluated decision within
+ * that evaluation, joined by a hyphen (format: `<decisionEvaluationKey>-<index>`).
+ *
  */
 export type DecisionEvaluationInstanceKey = CamundaKey<'DecisionEvaluationInstanceKey'>;
 
@@ -5598,6 +5673,8 @@ export type MessageSubscriptionResult = {
     processDefinitionKey: ProcessDefinitionKey | null;
     /**
      * The process instance key associated with this message subscription.
+     * Only populated for intermediate event entities.
+     *
      */
     processInstanceKey: ProcessInstanceKey | null;
     /**
@@ -5613,6 +5690,8 @@ export type MessageSubscriptionResult = {
     elementId: ElementId;
     /**
      * The element instance key associated with this message subscription.
+     * Only populated for intermediate event entities.
+     *
      */
     elementInstanceKey: ElementInstanceKey | null;
     messageSubscriptionState: MessageSubscriptionStateEnum;
@@ -5628,6 +5707,35 @@ export type MessageSubscriptionResult = {
      * The correlation key of the message subscription.
      */
     correlationKey: string | null;
+    messageSubscriptionType: MessageSubscriptionTypeEnum;
+    /**
+     * The `zeebe:properties` extension properties extracted from the BPMN element associated
+     * with this subscription. Empty object when no properties are defined.
+     *
+     */
+    extensionProperties: {
+        [key: string]: string;
+    };
+    /**
+     * The name of the process definition associated with this message subscription.
+     */
+    processDefinitionName: string | null;
+    /**
+     * The version of the process definition associated with this message subscription.
+     */
+    processDefinitionVersion: number | null;
+    /**
+     * Tool name extracted from the `io.camunda.tool:name` zeebe:property.
+     * Null when the property is absent.
+     *
+     */
+    toolName: string | null;
+    /**
+     * Inbound connector type extracted from the `inbound.type` zeebe:property.
+     * Null when the property is absent.
+     *
+     */
+    inboundConnectorType: string | null;
     tenantId: TenantId;
 };
 
@@ -5635,7 +5743,7 @@ export type MessageSubscriptionSearchQuerySortRequest = {
     /**
      * The field to sort by.
      */
-    field: 'messageSubscriptionKey' | 'processDefinitionId' | 'processInstanceKey' | 'elementId' | 'elementInstanceKey' | 'messageSubscriptionState' | 'lastUpdatedDate' | 'messageName' | 'correlationKey' | 'tenantId';
+    field: 'messageSubscriptionKey' | 'processDefinitionId' | 'processDefinitionName' | 'processDefinitionVersion' | 'processInstanceKey' | 'elementId' | 'elementInstanceKey' | 'messageSubscriptionState' | 'messageSubscriptionType' | 'lastUpdatedDate' | 'messageName' | 'correlationKey' | 'tenantId' | 'toolName' | 'inboundConnectorType';
     order?: SortOrderEnum;
 };
 
@@ -5698,6 +5806,29 @@ export type MessageSubscriptionFilter = {
      * The unique external tenant ID.
      */
     tenantId?: StringFilterProperty;
+    /**
+     * The type of message subscription to filter by. When omitted, both
+     * `START_EVENT` and `PROCESS_EVENT` are returned. Only available for data
+     * created with Camunda 8.10 or later.
+     *
+     */
+    messageSubscriptionType?: MessageSubscriptionTypeFilterProperty;
+    /**
+     * The name of the process definition associated with this message subscription.
+     */
+    processDefinitionName?: StringFilterProperty;
+    /**
+     * The version of the process definition associated with this message subscription.
+     */
+    processDefinitionVersion?: IntegerFilterProperty;
+    /**
+     * Filter by tool name extracted from the `io.camunda.tool:name` zeebe:property.
+     */
+    toolName?: StringFilterProperty;
+    /**
+     * Filter by inbound connector type extracted from the `inbound.type` zeebe:property.
+     */
+    inboundConnectorType?: StringFilterProperty;
 };
 
 export type CorrelatedMessageSubscriptionSearchQueryResult = SearchQueryResponse & {
@@ -5797,6 +5928,19 @@ export const MessageSubscriptionStateEnum = {
 } as const;
 export type MessageSubscriptionStateEnum = (typeof MessageSubscriptionStateEnum)[keyof typeof MessageSubscriptionStateEnum];
 /**
+ * The type of message subscription.
+ * `START_EVENT` is definition-scoped (process start events). Always has a value; only
+ * captured from Camunda 8.10 onwards.
+ * `PROCESS_EVENT` is instance-scoped (intermediate catch events). Pre-8.10 entries have
+ * no value stored; the API returns `PROCESS_EVENT` as a default for those entries.
+ *
+ */
+export const MessageSubscriptionTypeEnum = {
+  START_EVENT: 'START_EVENT',
+  PROCESS_EVENT: 'PROCESS_EVENT',
+} as const;
+export type MessageSubscriptionTypeEnum = (typeof MessageSubscriptionTypeEnum)[keyof typeof MessageSubscriptionTypeEnum];
+/**
  * Correlated message subscriptions search filter.
  */
 export type CorrelatedMessageSubscriptionFilter = {
@@ -5848,6 +5992,36 @@ export type CorrelatedMessageSubscriptionFilter = {
      * The tenant ID associated with this correlated message subscription.
      */
     tenantId?: StringFilterProperty;
+};
+
+/**
+ * MessageSubscriptionTypeEnum with full advanced search capabilities.
+ */
+export type MessageSubscriptionTypeFilterProperty = MessageSubscriptionTypeExactMatch | AdvancedMessageSubscriptionTypeFilter;
+
+/**
+ * Advanced filter
+ *
+ * Advanced MessageSubscriptionTypeEnum filter
+ */
+export type AdvancedMessageSubscriptionTypeFilter = {
+    /**
+     * Checks for equality with the provided value.
+     */
+    $eq?: MessageSubscriptionTypeEnum;
+    /**
+     * Checks for inequality with the provided value.
+     */
+    $neq?: MessageSubscriptionTypeEnum;
+    /**
+     * Checks if the current property exists.
+     */
+    $exists?: boolean;
+    /**
+     * Checks if the property matches any of the provided values.
+     */
+    $in?: Array<MessageSubscriptionTypeEnum>;
+    $like?: LikeFilter;
 };
 
 /**
@@ -7803,7 +7977,7 @@ export type UserTaskFilter = {
     /**
      * The ID of the process definition.
      */
-    processDefinitionId?: ProcessDefinitionId;
+    processDefinitionId?: ProcessDefinitionIdFilterProperty;
     /**
      * The user task creation date.
      */
@@ -7835,11 +8009,11 @@ export type UserTaskFilter = {
     /**
      * The key of the process definition.
      */
-    processDefinitionKey?: ProcessDefinitionKey;
+    processDefinitionKey?: ProcessDefinitionKeyFilterProperty;
     /**
      * The key of the process instance.
      */
-    processInstanceKey?: ProcessInstanceKey;
+    processInstanceKey?: ProcessInstanceKeyFilterProperty;
     /**
      * The key of the element instance.
      */
@@ -8581,6 +8755,20 @@ export type GlobalTaskListenerEventTypeExactMatch = GlobalTaskListenerEventTypeE
  *
  * Matches the value exactly.
  */
+export type ElementIdExactMatch = ElementId;
+
+/**
+ * Exact match
+ *
+ * Matches the value exactly.
+ */
+export type ProcessDefinitionIdExactMatch = ProcessDefinitionId;
+
+/**
+ * Exact match
+ *
+ * Matches the value exactly.
+ */
 export type IncidentErrorTypeExactMatch = IncidentErrorTypeEnum;
 
 /**
@@ -8694,6 +8882,13 @@ export type DecisionEvaluationKeyExactMatch = DecisionEvaluationKey;
  * Matches the value exactly.
  */
 export type DecisionRequirementsKeyExactMatch = DecisionRequirementsKey;
+
+/**
+ * Exact match
+ *
+ * Matches the value exactly.
+ */
+export type MessageSubscriptionTypeExactMatch = MessageSubscriptionTypeEnum;
 
 /**
  * Exact match
@@ -9584,6 +9779,10 @@ export type CreateTenantClusterVariableErrors = {
      * Forbidden. The request is not allowed.
      */
     403: ProblemDetail;
+    /**
+     * The tenant with the given ID was not found.
+     */
+    404: ProblemDetail;
     /**
      * An internal error occurred while processing the request.
      */
@@ -13987,7 +14186,7 @@ export type GetResourceContentResponses = {
     /**
      * The resource content is successfully returned.
      */
-    200: string;
+    200: Blob | File;
 };
 
 export type GetResourceContentResponse = GetResourceContentResponses[keyof GetResourceContentResponses];
@@ -16864,7 +17063,7 @@ export type GetVariableResponse = GetVariableResponses[keyof GetVariableResponse
 
 // branding-plugin generated
 // schemaVersion=1.0.0
-// specHash=sha256:23c77958ed5c8e6d5bec3a5368ea7cc9aef83d7a745bffdbf618c34ece760409
+// specHash=sha256:6d0560fde009abd591d2bf84c727edc92340880af0b54a90093ed40ebb97f973
 
 export function assertConstraint(value: string, label: string, c: { pattern?: string; minLength?: number; maxLength?: number }) {
   if (c.pattern && !(new RegExp(c.pattern, 'u').test(value))) throw new Error(`[31mInvalid pattern for ${label}: '${value}'.[0m Needs to match: ${JSON.stringify(c)}
@@ -16976,16 +17175,16 @@ export namespace DecisionDefinitionKey {
     } catch { return false; }
   }
 }
-// System-generated key for a decision evaluation instance.
+// System-generated identifier for a decision evaluation instance. It is composed of the parent decision evaluation key and the 1-based index of the evaluated decision within that evaluation, joined by a hyphen (format: `<decisionEvaluationKey>-<index>`). 
 export namespace DecisionEvaluationInstanceKey {
   export function assumeExists(value: string): DecisionEvaluationInstanceKey {
-    assertConstraint(value, 'DecisionEvaluationInstanceKey', { pattern: "^-?[0-9]+$", minLength: 1, maxLength: 25 });
+    assertConstraint(value, 'DecisionEvaluationInstanceKey', { pattern: "^[0-9]+-[0-9]+$", minLength: 3, maxLength: 30 });
     return value as any;
   }
   export function getValue(key: DecisionEvaluationInstanceKey): string { return key; }
   export function isValid(value: string): boolean {
     try {
-      assertConstraint(value, 'DecisionEvaluationInstanceKey', { pattern: "^-?[0-9]+$", minLength: 1, maxLength: 25 });
+      assertConstraint(value, 'DecisionEvaluationInstanceKey', { pattern: "^[0-9]+-[0-9]+$", minLength: 3, maxLength: 30 });
       return true;
     } catch { return false; }
   }

--- a/src/gen/zod.gen.ts
+++ b/src/gen/zod.gen.ts
@@ -1313,6 +1313,50 @@ export const zBusinessId = z.string().min(1).max(256).register(z.globalRegistry,
 });
 
 /**
+ * Advanced filter
+ *
+ * Advanced ElementId filter.
+ */
+export const zAdvancedElementIdFilter = z.object({
+    '$eq': z.optional(zElementId),
+    '$neq': z.optional(zElementId),
+    '$exists': z.optional(z.boolean().register(z.globalRegistry, {
+        description: 'Checks if the current property exists.'
+    })),
+    '$in': z.optional(z.array(zElementId).register(z.globalRegistry, {
+        description: 'Checks if the property matches any of the provided values.'
+    })),
+    '$notIn': z.optional(z.array(zElementId).register(z.globalRegistry, {
+        description: 'Checks if the property matches none of the provided values.'
+    })),
+    '$like': z.optional(zLikeFilter)
+}).register(z.globalRegistry, {
+    description: 'Advanced ElementId filter.'
+});
+
+/**
+ * Advanced filter
+ *
+ * Advanced ProcessDefinitionId filter.
+ */
+export const zAdvancedProcessDefinitionIdFilter = z.object({
+    '$eq': z.optional(zProcessDefinitionId),
+    '$neq': z.optional(zProcessDefinitionId),
+    '$exists': z.optional(z.boolean().register(z.globalRegistry, {
+        description: 'Checks if the current property exists.'
+    })),
+    '$in': z.optional(z.array(zProcessDefinitionId).register(z.globalRegistry, {
+        description: 'Checks if the property matches any of the provided values.'
+    })),
+    '$notIn': z.optional(z.array(zProcessDefinitionId).register(z.globalRegistry, {
+        description: 'Checks if the property matches none of the provided values.'
+    })),
+    '$like': z.optional(zLikeFilter)
+}).register(z.globalRegistry, {
+    description: 'Advanced ProcessDefinitionId filter.'
+});
+
+/**
  * Incident error type with a defined set of values.
  */
 export const zIncidentErrorTypeEnum = z.enum([
@@ -1816,6 +1860,7 @@ export const zJobKindEnum = z.enum([
  */
 export const zJobListenerEventTypeEnum = z.enum([
     'ASSIGNING',
+    'BEFORE_ALL',
     'CANCELING',
     'COMPLETING',
     'CREATING',
@@ -2440,9 +2485,14 @@ export const zDecisionEvaluationInstruction = z.union([
 ]);
 
 /**
- * System-generated key for a decision evaluation instance.
+ * System-generated identifier for a decision evaluation instance. It is composed of the
+ * parent decision evaluation key and the 1-based index of the evaluated decision within
+ * that evaluation, joined by a hyphen (format: `<decisionEvaluationKey>-<index>`).
+ *
  */
-export const zDecisionEvaluationInstanceKey = zLongKey;
+export const zDecisionEvaluationInstanceKey = z.string().min(3).max(30).regex(/^[0-9]+-[0-9]+$/).register(z.globalRegistry, {
+    description: 'System-generated identifier for a decision evaluation instance. It is composed of the\nparent decision evaluation key and the 1-based index of the evaluated decision within\nthat evaluation, joined by a hyphen (format: `<decisionEvaluationKey>-<index>`).\n'
+});
 
 /**
  * A decision that was evaluated.
@@ -2863,7 +2913,10 @@ export const zBatchOperationItemResponse = z.object({
     itemKey: z.string().register(z.globalRegistry, {
         description: 'Key of the item, e.g. a process instance key.'
     }),
-    processInstanceKey: zProcessInstanceKey,
+    processInstanceKey: z.union([
+        zProcessInstanceKey,
+        z.null()
+    ]),
     rootProcessInstanceKey: z.union([
         zProcessInstanceKey,
         z.null()
@@ -3440,6 +3493,40 @@ export const zMessageSubscriptionStateEnum = z.enum([
 });
 
 /**
+ * The type of message subscription.
+ * `START_EVENT` is definition-scoped (process start events). Always has a value; only
+ * captured from Camunda 8.10 onwards.
+ * `PROCESS_EVENT` is instance-scoped (intermediate catch events). Pre-8.10 entries have
+ * no value stored; the API returns `PROCESS_EVENT` as a default for those entries.
+ *
+ */
+export const zMessageSubscriptionTypeEnum = z.enum([
+    'START_EVENT',
+    'PROCESS_EVENT'
+]).register(z.globalRegistry, {
+    description: 'The type of message subscription.\n`START_EVENT` is definition-scoped (process start events). Always has a value; only\ncaptured from Camunda 8.10 onwards.\n`PROCESS_EVENT` is instance-scoped (intermediate catch events). Pre-8.10 entries have\nno value stored; the API returns `PROCESS_EVENT` as a default for those entries.\n'
+});
+
+/**
+ * Advanced filter
+ *
+ * Advanced MessageSubscriptionTypeEnum filter
+ */
+export const zAdvancedMessageSubscriptionTypeFilter = z.object({
+    '$eq': z.optional(zMessageSubscriptionTypeEnum),
+    '$neq': z.optional(zMessageSubscriptionTypeEnum),
+    '$exists': z.optional(z.boolean().register(z.globalRegistry, {
+        description: 'Checks if the current property exists.'
+    })),
+    '$in': z.optional(z.array(zMessageSubscriptionTypeEnum).register(z.globalRegistry, {
+        description: 'Checks if the property matches any of the provided values.'
+    })),
+    '$like': z.optional(zLikeFilter)
+}).register(z.globalRegistry, {
+    description: 'Advanced MessageSubscriptionTypeEnum filter'
+});
+
+/**
  * Advanced filter
  *
  * Advanced MessageSubscriptionStateEnum filter
@@ -3491,6 +3578,26 @@ export const zMessageSubscriptionResult = z.object({
         description: 'The name of the message associated with the message subscription.'
     }),
     correlationKey: z.union([
+        z.string(),
+        z.null()
+    ]),
+    messageSubscriptionType: zMessageSubscriptionTypeEnum,
+    extensionProperties: z.record(z.string(), z.string()).register(z.globalRegistry, {
+        description: 'The `zeebe:properties` extension properties extracted from the BPMN element associated\nwith this subscription. Empty object when no properties are defined.\n'
+    }),
+    processDefinitionName: z.union([
+        z.string(),
+        z.null()
+    ]),
+    processDefinitionVersion: z.union([
+        z.int(),
+        z.null()
+    ]),
+    toolName: z.union([
+        z.string(),
+        z.null()
+    ]),
+    inboundConnectorType: z.union([
         z.string(),
         z.null()
     ]),
@@ -4780,14 +4887,19 @@ export const zMessageSubscriptionSearchQuerySortRequest = z.object({
     field: z.enum([
         'messageSubscriptionKey',
         'processDefinitionId',
+        'processDefinitionName',
+        'processDefinitionVersion',
         'processInstanceKey',
         'elementId',
         'elementInstanceKey',
         'messageSubscriptionState',
+        'messageSubscriptionType',
         'lastUpdatedDate',
         'messageName',
         'correlationKey',
-        'tenantId'
+        'tenantId',
+        'toolName',
+        'inboundConnectorType'
     ]).register(z.globalRegistry, {
         description: 'The field to sort by.'
     }),
@@ -6307,77 +6419,6 @@ export const zElementInstanceStateFilterProperty = z.union([
 ]);
 
 /**
- * Element instance filter.
- */
-export const zElementInstanceFilter = z.object({
-    processDefinitionId: z.optional(zProcessDefinitionId),
-    state: z.optional(zElementInstanceStateFilterProperty),
-    type: z.optional(z.enum([
-        'UNSPECIFIED',
-        'PROCESS',
-        'SUB_PROCESS',
-        'EVENT_SUB_PROCESS',
-        'AD_HOC_SUB_PROCESS',
-        'AD_HOC_SUB_PROCESS_INNER_INSTANCE',
-        'START_EVENT',
-        'INTERMEDIATE_CATCH_EVENT',
-        'INTERMEDIATE_THROW_EVENT',
-        'BOUNDARY_EVENT',
-        'END_EVENT',
-        'SERVICE_TASK',
-        'RECEIVE_TASK',
-        'USER_TASK',
-        'MANUAL_TASK',
-        'TASK',
-        'EXCLUSIVE_GATEWAY',
-        'INCLUSIVE_GATEWAY',
-        'PARALLEL_GATEWAY',
-        'EVENT_BASED_GATEWAY',
-        'SEQUENCE_FLOW',
-        'MULTI_INSTANCE_BODY',
-        'CALL_ACTIVITY',
-        'BUSINESS_RULE_TASK',
-        'SCRIPT_TASK',
-        'SEND_TASK',
-        'UNKNOWN'
-    ]).register(z.globalRegistry, {
-        description: 'Type of element as defined set of values.'
-    })),
-    elementId: z.optional(zElementId),
-    elementName: z.optional(z.string().register(z.globalRegistry, {
-        description: "The element name. This only works for data created with 8.8 and onwards. Instances from prior versions don't contain this data and cannot be found.\n"
-    })),
-    hasIncident: z.optional(z.boolean().register(z.globalRegistry, {
-        description: 'Shows whether this element instance has an incident related to.'
-    })),
-    tenantId: z.optional(zTenantId),
-    elementInstanceKey: z.optional(zElementInstanceKey),
-    processInstanceKey: z.optional(zProcessInstanceKey),
-    processDefinitionKey: z.optional(zProcessDefinitionKey),
-    incidentKey: z.optional(zIncidentKey),
-    startDate: z.optional(zDateTimeFilterProperty),
-    endDate: z.optional(zDateTimeFilterProperty),
-    elementInstanceScopeKey: z.optional(z.union([
-        zElementInstanceKey,
-        zProcessInstanceKey
-    ]))
-}).register(z.globalRegistry, {
-    description: 'Element instance filter.'
-});
-
-/**
- * Element instance search request.
- */
-export const zElementInstanceSearchQuery = zSearchQueryRequest.and(z.object({
-    sort: z.optional(z.array(zElementInstanceSearchQuerySortRequest).register(z.globalRegistry, {
-        description: 'Sort field criteria.'
-    })),
-    filter: z.optional(zElementInstanceFilter)
-}).register(z.globalRegistry, {
-    description: 'Element instance search request.'
-}));
-
-/**
  * Exact match
  *
  * Matches the value exactly.
@@ -6437,6 +6478,105 @@ export const zGlobalTaskListenerSearchQueryRequest = zSearchQueryRequest.and(z.o
 }).register(z.globalRegistry, {
     description: 'Global listener search query request.'
 }));
+
+/**
+ * Exact match
+ *
+ * Matches the value exactly.
+ */
+export const zElementIdExactMatch = zElementId;
+
+/**
+ * ElementId property with full advanced search capabilities.
+ */
+export const zElementIdFilterProperty = z.union([
+    zElementIdExactMatch,
+    zAdvancedElementIdFilter
+]);
+
+/**
+ * Element instance filter.
+ */
+export const zElementInstanceFilter = z.object({
+    processDefinitionId: z.optional(zProcessDefinitionId),
+    state: z.optional(zElementInstanceStateFilterProperty),
+    type: z.optional(z.enum([
+        'UNSPECIFIED',
+        'PROCESS',
+        'SUB_PROCESS',
+        'EVENT_SUB_PROCESS',
+        'AD_HOC_SUB_PROCESS',
+        'AD_HOC_SUB_PROCESS_INNER_INSTANCE',
+        'START_EVENT',
+        'INTERMEDIATE_CATCH_EVENT',
+        'INTERMEDIATE_THROW_EVENT',
+        'BOUNDARY_EVENT',
+        'END_EVENT',
+        'SERVICE_TASK',
+        'RECEIVE_TASK',
+        'USER_TASK',
+        'MANUAL_TASK',
+        'TASK',
+        'EXCLUSIVE_GATEWAY',
+        'INCLUSIVE_GATEWAY',
+        'PARALLEL_GATEWAY',
+        'EVENT_BASED_GATEWAY',
+        'SEQUENCE_FLOW',
+        'MULTI_INSTANCE_BODY',
+        'CALL_ACTIVITY',
+        'BUSINESS_RULE_TASK',
+        'SCRIPT_TASK',
+        'SEND_TASK',
+        'UNKNOWN'
+    ]).register(z.globalRegistry, {
+        description: 'Type of element as defined set of values.'
+    })),
+    elementId: z.optional(zElementIdFilterProperty),
+    elementName: z.optional(zStringFilterProperty),
+    hasIncident: z.optional(z.boolean().register(z.globalRegistry, {
+        description: 'Shows whether this element instance has an incident related to.'
+    })),
+    tenantId: z.optional(zTenantId),
+    elementInstanceKey: z.optional(zElementInstanceKey),
+    processInstanceKey: z.optional(zProcessInstanceKey),
+    processDefinitionKey: z.optional(zProcessDefinitionKey),
+    incidentKey: z.optional(zIncidentKey),
+    startDate: z.optional(zDateTimeFilterProperty),
+    endDate: z.optional(zDateTimeFilterProperty),
+    elementInstanceScopeKey: z.optional(z.union([
+        zElementInstanceKey,
+        zProcessInstanceKey
+    ]))
+}).register(z.globalRegistry, {
+    description: 'Element instance filter.'
+});
+
+/**
+ * Element instance search request.
+ */
+export const zElementInstanceSearchQuery = zSearchQueryRequest.and(z.object({
+    sort: z.optional(z.array(zElementInstanceSearchQuerySortRequest).register(z.globalRegistry, {
+        description: 'Sort field criteria.'
+    })),
+    filter: z.optional(zElementInstanceFilter)
+}).register(z.globalRegistry, {
+    description: 'Element instance search request.'
+}));
+
+/**
+ * Exact match
+ *
+ * Matches the value exactly.
+ */
+export const zProcessDefinitionIdExactMatch = zProcessDefinitionId;
+
+/**
+ * ProcessDefinitionId property with full advanced search capabilities.
+ */
+export const zProcessDefinitionIdFilterProperty = z.union([
+    zProcessDefinitionIdExactMatch,
+    zAdvancedProcessDefinitionIdFilter
+]);
 
 /**
  * Exact match
@@ -6927,6 +7067,21 @@ export const zDecisionInstanceSearchQuery = zSearchQueryRequest.and(z.object({
  *
  * Matches the value exactly.
  */
+export const zMessageSubscriptionTypeExactMatch = zMessageSubscriptionTypeEnum;
+
+/**
+ * MessageSubscriptionTypeEnum with full advanced search capabilities.
+ */
+export const zMessageSubscriptionTypeFilterProperty = z.union([
+    zMessageSubscriptionTypeExactMatch,
+    zAdvancedMessageSubscriptionTypeFilter
+]);
+
+/**
+ * Exact match
+ *
+ * Matches the value exactly.
+ */
 export const zMessageSubscriptionStateExactMatch = zMessageSubscriptionStateEnum;
 
 /**
@@ -6966,7 +7121,12 @@ export const zMessageSubscriptionFilter = z.object({
     lastUpdatedDate: z.optional(zDateTimeFilterProperty),
     messageName: z.optional(zStringFilterProperty),
     correlationKey: z.optional(zStringFilterProperty),
-    tenantId: z.optional(zStringFilterProperty)
+    tenantId: z.optional(zStringFilterProperty),
+    messageSubscriptionType: z.optional(zMessageSubscriptionTypeFilterProperty),
+    processDefinitionName: z.optional(zStringFilterProperty),
+    processDefinitionVersion: z.optional(zIntegerFilterProperty),
+    toolName: z.optional(zStringFilterProperty),
+    inboundConnectorType: z.optional(zStringFilterProperty)
 }).register(z.globalRegistry, {
     description: 'Message subscription search filter.'
 });
@@ -7190,7 +7350,7 @@ export const zUserTaskFilter = z.object({
     candidateGroup: z.optional(zStringFilterProperty),
     candidateUser: z.optional(zStringFilterProperty),
     tenantId: z.optional(zStringFilterProperty),
-    processDefinitionId: z.optional(zProcessDefinitionId),
+    processDefinitionId: z.optional(zProcessDefinitionIdFilterProperty),
     creationDate: z.optional(zDateTimeFilterProperty),
     completionDate: z.optional(zDateTimeFilterProperty),
     followUpDate: z.optional(zDateTimeFilterProperty),
@@ -7202,8 +7362,8 @@ export const zUserTaskFilter = z.object({
         description: 'The local variables of the user task.'
     })),
     userTaskKey: z.optional(zUserTaskKey),
-    processDefinitionKey: z.optional(zProcessDefinitionKey),
-    processInstanceKey: z.optional(zProcessInstanceKey),
+    processDefinitionKey: z.optional(zProcessDefinitionKeyFilterProperty),
+    processInstanceKey: z.optional(zProcessInstanceKeyFilterProperty),
     elementInstanceKey: z.optional(zElementInstanceKey),
     tags: z.optional(zTagSet)
 }).register(z.globalRegistry, {

--- a/tests-integration/bootstrap.test.ts
+++ b/tests-integration/bootstrap.test.ts
@@ -25,14 +25,18 @@ describe('integration acceptance', () => {
     const res = await camunda.getAuthentication();
     expect(res).toBeDefined();
   });
-  it('throws when using a Blob instead of File (invalid resources array)', async () => {
+  it('accepts a Blob without a filename and falls back to resourceName "blob"', async () => {
+    // Behavioural change in Camunda 8.x server (arrived alongside the 8.7 spec bump in PR #174):
+    // multipart parts without a filename are no longer rejected; the server defaults
+    // resourceName to "blob" and proceeds with the deployment. This is server behaviour, not
+    // spec-defined — the spec only requires `resources` to be an array of binary parts.
     const buffer = await fs.promises.readFile('./tests-integration/fixtures/test-process.bpmn');
     const copied = Uint8Array.from(buffer);
     const blob = new Blob([copied], { type: 'application/xml' });
     const camunda = createCamundaClient({ throwOnError: true });
-    await expect(
-      camunda.createDeployment({ resources: [blob as any] } as any)
-    ).rejects.toBeDefined();
+    const result = await camunda.createDeployment({ resources: [blob as any] } as any);
+    expect(result.deploymentKey).toBeDefined();
+    expect(result.deployments?.[0]?.resource?.resourceName).toBe('blob');
   });
 
   // This won't throw if the broker is not using Basic Auth
@@ -52,14 +56,16 @@ describe('integration acceptance', () => {
     await expect(camunda.createDeployment({ resources: [file] } as any)).rejects.toBeDefined();
   });
 
-  it('returns Result (ok:false) with CamundaResultClient instead of throwing', async () => {
+  it('returns Result (ok:true) with CamundaResultClient for a Blob deployment', async () => {
+    // See note on the Blob-without-filename test above: the server now accepts this and
+    // resolves to a successful deployment, so the Result wrapper reports ok:true.
     const buffer = await fs.promises.readFile('./tests-integration/fixtures/test-process.bpmn');
     const copied = Uint8Array.from(buffer);
     const blob = new Blob([copied], { type: 'application/xml' });
     const client = createCamundaResultClient({});
     const res = await (client as any).createDeployment({ resources: [blob as any] });
-    expect(res.ok).toBe(false);
-    expect(res.error).toBeDefined();
+    expect(res.ok).toBe(true);
+    expect(res.value?.deploymentKey).toBeDefined();
   });
 
   it('can activate jobs, and the job has a tag', { timeout: 20000 }, async () => {

--- a/tests/inject-examples.test.ts
+++ b/tests/inject-examples.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  type ExampleRef,
   extractRegionFromContent,
   injectExamples,
-  type ExampleRef,
 } from '../hooks/post/450-inject-examples';
 
 // ── extractRegionFromContent ────────────────────────────────────────────

--- a/tests/runtime-enums.test.ts
+++ b/tests/runtime-enums.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import * as SDK from '../src';
 import {
   DecisionDefinitionTypeEnum,
   GlobalTaskListenerEventTypeEnum,
@@ -8,7 +9,6 @@ import {
   PermissionTypeEnum,
   SortOrderEnum,
 } from '../src';
-import * as SDK from '../src';
 
 describe('runtime enum objects', () => {
   it('PermissionTypeEnum exposes values at runtime', () => {

--- a/tests/worker-type-honesty.test.ts
+++ b/tests/worker-type-honesty.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createCamundaClient, CamundaClient } from '../src';
+import { CamundaClient, createCamundaClient } from '../src';
 import { JobWorker } from '../src/runtime/jobWorker';
 import { ThreadedJobWorker } from '../src/runtime/threadedJobWorker';
 


### PR DESCRIPTION
## Summary

Three upstream-driven behavioural changes that consumers should be aware of when upgrading to the next major (10.x):

### 1. `getResource` / `getResourceContent` are now eventually consistent

Callers must pass an explicit `consistencyManagement` argument; the SDK uses `eventualPoll` under the hood.

```ts
// Before
await camunda.getResource({ resourceKey });

// After
await camunda.getResource(
  { resourceKey },
  { consistency: { waitUpToMs: 0 } }
);
```

### 2. `DecisionEvaluationInstanceKey` format change

Changed from a numeric `LongKey` to a composite `<decisionEvaluationKey>-<index>` string.

| | Before | After |
| --- | --- | --- |
| Pattern | `^-?[0-9]+$` | `^[0-9]+-[0-9]+$` |
| Length | 1–25 | 3–30 |
| Example | `"2251799813684367"` | `"2251799813684367-1"` |

Code that hard-coded values, parsed them as numbers, or relied on the old `assumeExists` validation will need to be updated.

### 3. `createDeployment` now accepts multipart parts without a filename

The Camunda server matched by this spec bump no longer rejects multipart parts that lack a filename; it falls back to `resourceName: "blob"` and proceeds. This is server behaviour (the spec only requires `resources` to be an array of binary parts), but it surfaces here because the integration tests previously asserted the old reject behaviour.

If your code defensively rejected `Blob` (vs `File`) inputs upstream of `createDeployment`, you can drop those checks — the deployment will succeed with `resourceName: "blob"`. Two integration tests in `tests-integration/bootstrap.test.ts` were inverted to document the new contract.

## Scope

All three changes are sourced from the upstream OpenAPI spec / matched server version; the SDK is regenerated to match. This branch will land in the next major (10.x) via the normal stable promotion — no `BREAKING CHANGE:` footer is used because we don't want semantic-release on `main` to auto-major from this commit.
