### PR TITLE
ci: fix compose log artifact path so failure logs actually upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           if [ "${{ matrix.stack }}" == "full" ]; then
             COMPOSE_FILE="docker/docker-compose-full.yaml"
           fi
-          docker compose -f $COMPOSE_FILE logs > ../_logs/compose.log 2>&1 || true
+          docker compose -f $COMPOSE_FILE logs > _logs/compose.log 2>&1 || true
       - name: Shutdown Integration Stack (always)
         if: always()
         working-directory: docker


### PR DESCRIPTION
## Why

The `Capture Docker Logs (always)` step runs from the repo root (no `working-directory` set) but redirects to `../_logs/compose.log`, which lands one directory above the repo. The subsequent `Upload Logs Artifact (on failure)` step looks for `_logs/compose.log` relative to the repo root and finds nothing, so failure logs have never actually been attached as artifacts.

This was discovered while triaging the recent `8.9-SNAPSHOT` boot crashes (#175 / #176): we wanted to attach the upstream stack trace to a Camunda issue, and there was no log artifact to attach.

## What

`docker compose ... logs > ../_logs/compose.log` → `docker compose ... logs > _logs/compose.log`.

Matches the path already used correctly in `orchestration-cluster-api-csharp/.github/workflows/ci.yml`.

## Backport

This bug exists on `stable/9` too. Happy to cherry-pick after this lands if you'd like — let me know.