### PR TITLE
ci: fix compose log artifact path so failure logs actually upload (backport #177 to stable/9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           if [ "${{ matrix.stack }}" == "full" ]; then
             COMPOSE_FILE="docker/docker-compose-full.yaml"
           fi
-          docker compose -f $COMPOSE_FILE logs > ../_logs/compose.log 2>&1 || true
+          docker compose -f $COMPOSE_FILE logs > _logs/compose.log 2>&1 || true
       - name: Shutdown Integration Stack (always)
         if: always()
         working-directory: docker


### PR DESCRIPTION
Backport of #177 to `stable/9`.

Same one-line fix: drop the stray `../` so `_logs/compose.log` lands inside the repo where `actions/upload-artifact` looks for it.

Cherry-picked clean from `bd159d6f0` on main.