### PR TITLE
fix(docker): resolve ambiguous numberOfReplicas config in full compose stack

### DIFF
--- a/docker/docker-compose-full.yaml
+++ b/docker/docker-compose-full.yaml
@@ -131,10 +131,10 @@ configs:
                 email: "demo@demo.com"
             defaultRoles.admin.users:
               - "demo"
-        database.index.numberOfReplicas: 0 # Single node elasticsearch so we disable replication
         data:
           secondary-storage:
             type: elasticsearch
             elasticsearch:
               cluster-name: elasticsearch
               url: "http://elasticsearch:9200"
+              number-of-replicas: 0 # Single node elasticsearch so we disable replication


### PR DESCRIPTION
## Why

CI on `main` has been failing because the orchestration container exits ~10s after start. Reproduced locally with `camunda/camunda:8.9.2` and the failure is a Spring boot crash:

```
Ambiguous configuration. The value
camunda.data.secondary-storage.elasticsearch.number-of-replicas=1
conflicts with the values '0' from the legacy properties
camunda.database.index.numberOfReplicas, zeebe.broker.exporters.camundaexporter.args.index.numberOfReplicas
```

Newer Camunda 8.9.x rejects ambiguous configuration when both the legacy and new property paths are present with conflicting values. The `docker-compose-full.yaml` config had:

- legacy: `camunda.database.index.numberOfReplicas: 0`
- new: `camunda.data.secondary-storage.elasticsearch.*` (which defaults `number-of-replicas` to `1`)

## What

Move `number-of-replicas: 0` under the new `secondary-storage.elasticsearch` block and drop the legacy line.

## Verification

Locally with `CAMUNDA_VERSION=8.10-SNAPSHOT docker compose -f docker-compose-full.yaml up -d`: orchestration reaches Healthy and connectors start.

## Context

This is the same fix already merged to `stable/9` via #176 and previously pushed to #175 (which had already merged before the fix push, so the fix never landed on main). Splitting it out into its own PR is the cleanest path forward.