### PR TITLE
docs: add searchResources example

### DIFF
--- a/examples/admin-operations.ts
+++ b/examples/admin-operations.ts
@@ -309,6 +309,21 @@ async function getResourceContentExample(resourceKey: ProcessDefinitionKey) {
 }
 //#endregion GetResourceContent
 
+//#region SearchResources
+async function searchResourcesExample() {
+  const camunda = createCamundaClient();
+
+  const result = await camunda.searchResources(
+    { page: { limit: 10 } },
+    { consistency: { waitUpToMs: 5000 } }
+  );
+
+  for (const resource of result.items ?? []) {
+    console.log(`Resource: ${resource.resourceName}`);
+  }
+}
+//#endregion SearchResources
+
 //#region GetUsageMetrics
 async function getUsageMetricsExample() {
   const camunda = createCamundaClient();
@@ -538,6 +553,7 @@ void evaluateConditionalsExample;
 void evaluateExpressionExample;
 void getResourceExample;
 void getResourceContentExample;
+void searchResourcesExample;
 void getUsageMetricsExample;
 void searchMessageSubscriptionsExample;
 void searchCorrelatedMessageSubscriptionsExample;

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -1178,6 +1178,13 @@
       "label": "Get resource content"
     }
   ],
+  "searchResources": [
+    {
+      "file": "admin-operations.ts",
+      "region": "SearchResources",
+      "label": "Search resources"
+    }
+  ],
   "getUsageMetrics": [
     {
       "file": "admin-operations.ts",


### PR DESCRIPTION
## Summary

Adds the missing `searchResources` example to fix the `check-example-coverage` CI gate.

The upstream spec added `POST /resources/search` (`searchResources` operationId). CI regenerates the SDK from the latest upstream spec before running coverage checks, so the generated types will exist when the check runs.

### Changes

- Added `SearchResources` example region in `examples/admin-operations.ts`
- Added `searchResources` entry in `examples/operation-map.json`
- Added `void searchResourcesExample` suppression