### PR TITLE
feat: add example coverage for 4 new operations

### DIFF
--- a/examples/admin-operations.ts
+++ b/examples/admin-operations.ts
@@ -6,6 +6,7 @@ import {
   type AuditLogKey,
   type ClusterVariableName,
   createCamundaClient,
+  type FormKey,
   type GlobalListenerId,
   type ProcessDefinitionKey,
   type TenantId,
@@ -310,6 +311,36 @@ async function getResourceContentExample(resourceKey: ProcessDefinitionKey) {
 }
 //#endregion GetResourceContent
 
+//#region GetResourceContentBinary
+async function getResourceContentBinaryExample(resourceKey: ProcessDefinitionKey) {
+  const camunda = createCamundaClient();
+
+  const content = await camunda.getResourceContentBinary(
+    {
+      resourceKey,
+    },
+    { consistency: { waitUpToMs: 0 } }
+  );
+
+  console.log(`Binary content retrieved (type: ${typeof content})`);
+}
+//#endregion GetResourceContentBinary
+
+//#region GetFormByKey
+async function getFormByKeyExample(formKey: FormKey) {
+  const camunda = createCamundaClient();
+
+  const form = await camunda.getFormByKey(
+    {
+      formKey,
+    },
+    { consistency: { waitUpToMs: 5000 } }
+  );
+
+  console.log(`Form: ${form.formId}, version: ${form.version}`);
+}
+//#endregion GetFormByKey
+
 //#region SearchResources
 async function searchResourcesExample() {
   const camunda = createCamundaClient();
@@ -554,6 +585,8 @@ void evaluateConditionalsExample;
 void evaluateExpressionExample;
 void getResourceExample;
 void getResourceContentExample;
+void getResourceContentBinaryExample;
+void getFormByKeyExample;
 void searchResourcesExample;
 void getUsageMetricsExample;
 void searchMessageSubscriptionsExample;

--- a/examples/agent-instance.ts
+++ b/examples/agent-instance.ts
@@ -1,7 +1,11 @@
 // Compilable usage examples for agent instance operations.
 // These examples are type-checked during build to guard against API regressions.
 
-import { type AgentInstanceKey, createCamundaClient } from '@camunda8/orchestration-cluster-api';
+import {
+  type AgentInstanceKey,
+  createCamundaClient,
+  type ElementInstanceKey,
+} from '@camunda8/orchestration-cluster-api';
 
 //#region GetAgentInstance
 async function getAgentInstanceExample(agentInstanceKey: AgentInstanceKey) {
@@ -37,6 +41,43 @@ async function searchAgentInstancesExample() {
 }
 //#endregion SearchAgentInstances
 
+//#region CreateAgentInstance
+async function createAgentInstanceExample(elementInstanceKey: ElementInstanceKey) {
+  const camunda = createCamundaClient();
+
+  const result = await camunda.createAgentInstance({
+    elementInstanceKey,
+    definition: {
+      model: 'gpt-4o',
+      provider: 'openai',
+      systemPrompt: 'You are a helpful assistant.',
+    },
+  });
+
+  console.log(`Created agent instance: ${result.agentInstanceKey}`);
+}
+//#endregion CreateAgentInstance
+
+//#region UpdateAgentInstance
+async function updateAgentInstanceExample(agentInstanceKey: AgentInstanceKey) {
+  const camunda = createCamundaClient();
+
+  await camunda.updateAgentInstance({
+    agentInstanceKey,
+    status: 'THINKING',
+    metrics: {
+      inputTokens: 150,
+      outputTokens: 50,
+      modelCalls: 1,
+    },
+  });
+
+  console.log(`Updated agent instance: ${agentInstanceKey}`);
+}
+//#endregion UpdateAgentInstance
+
 // Suppress "declared but never read"
 void getAgentInstanceExample;
 void searchAgentInstancesExample;
+void createAgentInstanceExample;
+void updateAgentInstanceExample;

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -13,6 +13,20 @@
       "label": "Search agent instances"
     }
   ],
+  "createAgentInstance": [
+    {
+      "file": "agent-instance.ts",
+      "region": "CreateAgentInstance",
+      "label": "Create an agent instance"
+    }
+  ],
+  "updateAgentInstance": [
+    {
+      "file": "agent-instance.ts",
+      "region": "UpdateAgentInstance",
+      "label": "Update an agent instance"
+    }
+  ],
   "getTopology": [
     {
       "file": "client.ts",
@@ -856,6 +870,13 @@
       "label": "Get start process form"
     }
   ],
+  "getFormByKey": [
+    {
+      "file": "admin-operations.ts",
+      "region": "GetFormByKey",
+      "label": "Get a form by key"
+    }
+  ],
   "getVariable": [
     {
       "file": "extended-operations.ts",
@@ -1190,6 +1211,13 @@
       "file": "admin-operations.ts",
       "region": "GetResourceContent",
       "label": "Get resource content"
+    }
+  ],
+  "getResourceContentBinary": [
+    {
+      "file": "admin-operations.ts",
+      "region": "GetResourceContentBinary",
+      "label": "Get resource content as binary"
     }
   ],
   "searchResources": [


### PR DESCRIPTION
Add type-checked examples and operation-map entries for the 4 new operations introduced in the latest upstream spec:

- `createAgentInstance` (POST /agent-instances)
- `updateAgentInstance` (PATCH /agent-instances/{agentInstanceKey})
- `getFormByKey` (GET /forms/{formKey})
- `getResourceContentBinary` (GET /resources/{resourceKey}/content/binary)

Brings example coverage to 190/190 (100%).

**Files changed:**
- `examples/agent-instance.ts` — added `CreateAgentInstance` and `UpdateAgentInstance` regions
- `examples/admin-operations.ts` — added `GetResourceContentBinary` and `GetFormByKey` regions
- `examples/operation-map.json` — added 4 new entries

All examples are type-checked via `tsc --noEmit`.