### PR TITLE
chore(deps): restrict stable branch Dependabot to patch-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       interval: 'weekly'
     target-branch: 'stable/8'
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
 
   - package-ecosystem: 'npm'
     directory: '/'
@@ -20,6 +25,11 @@ updates:
       interval: 'weekly'
     target-branch: 'stable/9'
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## What

Restrict Dependabot updates targeting `stable/8` and `stable/9` to **patch versions only** by ignoring `semver-major` and `semver-minor` update types on the npm ecosystem configs for those branches.

`main` and `github-actions` (main-only) configs are unchanged.

## Why

`stable/8` and `stable/9` are maintenance branches. Major and minor dependency bumps carry risk of breaking changes and create review overhead — currently **38 open Dependabot PRs** across all branches, with many major version bumps on stable branches (TypeScript 5→6, @hey-api/openapi-ts 0.82→0.97, vitest 3→4, commitlint 20→21, p-retry 7→8).

Restricting to patches:
- Reduces noise — only security and bug-fix patches will be proposed for stable branches
- Avoids risky major/minor upgrades on maintenance branches
- Frees up `open-pull-requests-limit` slots for patches that actually matter

Note: there are also 10 orphaned PRs targeting `stable/8.8` from a previously removed config entry. Those will need to be manually closed.

## Impact

After merging, Dependabot will auto-close open stable-branch PRs that propose major or minor bumps.

### stable/8 PRs that would be auto-closed

| PR | Package | Bump |
|---|---|---|
| #130 | @typescript-eslint/eslint-plugin | 7.18.0 → 8.58.2 (major) |
| #132 | openapi-typescript-codegen | 0.29.0 → 0.30.0 (minor) |
| #133 | eslint-plugin-unused-imports | 3.2.0 → 4.4.1 (major) |
| #134 | p-retry | 7.1.1 → 8.0.0 (major) |
| #136 | typedoc-plugin-markdown | 4.9.0 → 4.11.0 (minor) |
| #138 | @types/node | 20.19.11 → 25.6.0 (major) |
| #140 | @hey-api/openapi-ts | 0.82.2 → 0.96.0 (minor) |
| #141 | vitest | 3.2.4 → 4.1.4 (major) |
| #142 | @commitlint/cli | 19.8.1 → 20.5.0 (major) |
| #143 | semantic-release | 25.0.2 → 25.0.3 (patch — **kept**) |

### stable/9 PRs that would be auto-closed

| PR | Package | Bump |
|---|---|---|
| #149 | typedoc | 0.28.18 → 0.28.19 (patch — **kept**) |
| #167 | typescript | 5.9.2 → 6.0.3 (major) |
| #198 | @hey-api/openapi-ts | 0.86.12 → 0.97.1 (minor) |
| #212 | @biomejs/biome | 2.4.10 → 2.4.15 (patch — **kept**) |
| #214 | @commitlint/config-conventional | 20.5.0 → 21.0.1 (major) |
| #215 | @types/node | 20.19.11 → 25.7.0 (major) |
| #216 | @commitlint/cli | 20.5.0 → 21.0.1 (major) |
| #217 | vitest | 3.2.4 → 4.1.6 (major) |
| #218 | camunda-schema-bundler | 2.1.0 → 2.4.1 (minor) |

Companion PRs: camunda/orchestration-cluster-api-csharp#188, camunda/orchestration-cluster-api-python (this PR's counterpart).