### PR TITLE
ci: add PR CI workflow for stable/8 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,121 @@
+name: PR & Branch CI
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - 'stable/**'
+  pull_request:
+    branches:
+      - main
+      - 'stable/**'
+
+jobs:
+  commitlint:
+    if: github.event_name == 'pull_request'
+    uses: camunda/sdk-infra/.github/workflows/sdk-commitlint.yml@v1
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20.x, 22.x, 24.x]
+        stack: [simple]
+        include:
+          - node: 22.x
+            stack: full
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - name: Install deps
+        run: npm ci
+      - name: Generate & Build
+        run: npm run build
+      - name: Detect Generation Drift (non-blocking)
+        id: drift
+        run: |
+          STATUS=$(git status --porcelain)
+          if [ -n "$STATUS" ]; then
+            echo 'drift=true' >> $GITHUB_OUTPUT
+            echo 'Generation produced changes (reporting only).' >&2
+            echo "$STATUS" | sed 's/^/CHANGED: /'
+            git add -A
+            git diff --cached > _gen-drift.patch || true
+            git reset HEAD
+          else
+            echo 'drift=false' >> $GITHUB_OUTPUT
+          fi
+      - name: Upload Drift Patch
+        if: steps.drift.outputs.drift == 'true' && matrix.node == '20.x' && matrix.stack == 'simple'
+        uses: actions/upload-artifact@v4
+        with:
+          name: generation-drift
+          path: _gen-drift.patch
+      - name: Unit Tests
+        run: npm test
+
+      - name: Start Integration Stack
+        working-directory: docker
+        run: |
+          if [ "${{ matrix.stack }}" == "full" ]; then
+            docker compose -f docker-compose-full.yaml up -d
+          else
+            docker compose -f docker-compose.yaml up -d
+          fi
+      - name: Wait for Services Healthy
+        run: |
+          set -e
+          attempts=0
+          max_attempts=60
+          while [ $attempts -lt $max_attempts ]; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9600/actuator/health/status || true)
+            [ "$code" = "200" ] && echo "Broker healthy" && break
+            sleep 5
+            attempts=$((attempts+1))
+          done
+          [ $attempts -ge $max_attempts ] && echo "Broker not healthy" && exit 1 || true
+      - name: Integration Tests
+        run: npm run test:integration
+      - name: Dump Docker Logs
+        if: always()
+        working-directory: docker
+        run: |
+          if [ "${{ matrix.stack }}" == "full" ]; then
+            docker compose -f docker-compose-full.yaml logs || true
+          else
+            docker compose -f docker-compose.yaml logs || true
+          fi
+      - name: Shutdown Integration Stack
+        if: always()
+        working-directory: docker
+        run: |
+          if [ "${{ matrix.stack }}" == "full" ]; then
+            docker compose -f docker-compose-full.yaml down -v || true
+          else
+            docker compose -f docker-compose.yaml down -v || true
+          fi
+
+      - name: Append Job Summary
+        if: always()
+        run: |
+          status="${{ job.status }}"
+          driftFlag="${{ steps.drift.outputs.drift }}"
+          {
+            echo "### Node ${{ matrix.node }} (${{ matrix.stack }}) Summary";
+            echo "- Status: ${status}";
+            if [ "${driftFlag}" = "true" ]; then
+              echo "- Generation Drift: detected";
+            else
+              echo "- Generation Drift: none";
+            fi
+            echo "";
+          } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What

Adds a `ci.yml` workflow to the `stable/8` branch so that PRs (including Dependabot PRs) get CI validation before merging.

## Why

The `stable/8` branch currently has no CI workflow — only `release.yml`. This means Dependabot PRs targeting `stable/8` have no automated checks, making it impossible to verify changes before merging.

## How

The workflow is based on `main`'s `ci.yml` but adapted for `stable/8`:

- **Commitlint**: Uses the shared `sdk-infra` reusable workflow
- **Build**: Runs `npm run build` (which includes generation) across Node 20.x, 22.x, and 24.x
- **Unit tests**: Explicit `npm test` step after build
- **Integration tests**: Uses inline `docker compose` commands (matching `stable/8`'s existing `release.yml` pattern) instead of `sdk-infra` composite actions, with `always()` log dumping before shutdown
- **Generation drift detection**: Reports changed/untracked files in CI logs and uploads a downloadable `.patch` artifact (from the Node 20.x/simple run to avoid duplicate artifact conflicts)

### Differences from `main`'s CI

| Feature | `main` CI | This CI (stable/8) |
|---|---|---|
| Example coverage checks | `check-example-coverage.cjs`, `check-method-example-completeness.cjs` | Omitted (scripts don't exist on stable/8) |
| Integration stack management | `sdk-infra/actions/start-camunda@v1` / `stop-camunda@v1` | Inline `docker compose` with log dump (matches release.yml) |
| Drift patch upload | ✅ | ✅ |
| Action versions | `checkout@v6`, `upload-artifact@v7` | `checkout@v5`, `upload-artifact@v4` (aligned with stable/8's release.yml) |
