### PR TITLE
feat: add Slack notifications for release failures and community events

### DIFF
--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -6,6 +6,8 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions: {}
+
 jobs:
   notify:
     uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1

--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -1,0 +1,16 @@
+name: Community & Dependabot Notifications
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  notify:
+    uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1
+    with:
+      repo-name: orchestration-cluster-api-js
+      mention-group: ${{ vars.SLACK_MENTION_GROUP }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,12 +291,13 @@ jobs:
           artifact-name: post-release-smoke-docker-logs
 
   notify-release-failure:
-    needs: [publish, post-release-smoke]
-    if: ${{ always() && (needs.publish.result == 'failure' || needs.post-release-smoke.result == 'failure') }}
+    needs: [generate, merge, publish, post-release-smoke]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     permissions: {}
     uses: camunda/sdk-infra/.github/workflows/sdk-slack-notify.yml@v1
     with:
       repo-name: orchestration-cluster-api-js
       workflow-name: Release
+      mention-group: ${{ vars.SLACK_MENTION_GROUP }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}


### PR DESCRIPTION
## What

Wires up the reusable Slack notification workflows from camunda/sdk-infra#8.

### Release failure notifications
- `notify-release-failure` now watches **all** pipeline jobs (`generate`, `merge`, `publish`, `post-release-smoke`) instead of only the terminal jobs
- Passes `mention-group` for urgent `@group` pings via `vars.SLACK_MENTION_GROUP`

### Community & Dependabot notifications
- New `community-notify.yml` triggers on `issues: [opened]` and `pull_request_target: [opened]`
- Community (non-member) issues/PRs → urgent notification with `@group` mention
- Dependabot PRs → non-urgent notification (no mention)
- Maintainer/collaborator activity → skipped

## Setup required

| Config | Type | Purpose |
|---|---|---|
| `SLACK_SDK_ALERTS` | Secret | Slack Incoming Webhook URL |
| `SLACK_MENTION_GROUP` | Variable | Slack group/subteam ID for `@mentions` |