### PR TITLE
feat: add searchVariablesAsDto for DTO-driven typed variable maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,41 @@ Benchmark results against a single-node local cluster with multiple independent 
 
 BALANCED wins 3 of 4 on pure throughput. The only scenario where LEGACY is faster is extreme overload (800 concurrent requests against a single broker) — and in that case LEGACY accumulates 44,505 errors vs BALANCED's 15,527. The default just works.
 
+## Typed Variable Map (DTO-driven search)
+
+`searchVariablesAsDto` fetches process variables and binds them to a [Zod](https://zod.dev) schema that acts as the DTO. The schema's keys are the exact variable names to fetch, and its shape drives validation. Only the declared variables are queried (via a `name $in [...]` filter), so memory stays bound by the DTO shape rather than the total number of variables on the instance. Results are paged internally until every declared variable is found or the result set is exhausted.
+
+The returned `VariableMap` offers two access modes:
+
+- **Lenient** — `has(name)` / `get(name)` for defensive reads that never throw on missing variables.
+- **Strict** — `validate()` returns a fully-typed object, or throws a `ZodError` when a required variable is missing or malformed.
+
+If a declared variable is found at more than one scope (for example a local variable shadowing a process-level one), the search throws a `VariableScopeCollisionError` rather than silently picking one. Pass an explicit `scopeKey` to disambiguate.
+
+<!-- snippet-source: examples/readme.ts | regions: ReadmeTypedVariables -->
+
+```ts
+// The Zod schema is the DTO: its keys are the variable names to fetch, and its
+// shape drives validation. Only these declared variables are queried, so memory
+// stays bound by the DTO — not by the total number of variables on the instance.
+const OrderVariables = z.object({
+  orderId: z.string(), // required
+  amount: z.number().optional(), // optional
+});
+
+const map = await camunda.searchVariablesAsDto(OrderVariables, { processInstanceKey });
+
+// Lenient access: defensive reads that never throw on missing variables.
+if (map.has('amount')) {
+  console.log('Amount:', map.get('amount'));
+}
+
+// Strict access: returns a fully-typed object, or throws a ZodError when a
+// required variable is missing or malformed.
+const order = map.validate(); // { orderId: string; amount?: number }
+console.log('Order:', order.orderId);
+```
+
 ## Job Workers (Polling API)
 
 The SDK provides a lightweight polling job worker for service task job types using `createJobWorker`. It activates jobs in batches (respecting a concurrency limit), validates variables (optional), and offers action helpers on each job.

--- a/examples/extended-operations.ts
+++ b/examples/extended-operations.ts
@@ -10,6 +10,7 @@ import {
   type ProcessInstanceKey,
   type VariableKey,
 } from '@camunda8/orchestration-cluster-api';
+import { z } from 'zod';
 
 //#region DeleteProcessInstance
 async function deleteProcessInstanceExample(processInstanceKey: ProcessInstanceKey) {
@@ -290,6 +291,32 @@ async function searchVariablesExample(processInstanceKey: ProcessInstanceKey) {
 }
 //#endregion SearchVariables
 
+//#region SearchVariablesAsDto
+async function searchVariablesAsDtoExample(processInstanceKey: ProcessInstanceKey) {
+  const camunda = createCamundaClient();
+
+  // The Zod schema is the DTO: its keys are the variable names to fetch, and its
+  // shape drives validation. Only these declared variables are queried, so memory
+  // stays bound by the DTO — not by the total number of variables on the instance.
+  const OrderVariables = z.object({
+    orderId: z.string(), // required
+    amount: z.number().optional(), // optional
+  });
+
+  const map = await camunda.searchVariablesAsDto(OrderVariables, { processInstanceKey });
+
+  // Lenient access: defensive reads that never throw on missing variables.
+  if (map.has('amount')) {
+    console.log('Amount:', map.get('amount'));
+  }
+
+  // Strict access: returns a fully-typed object, or throws a ZodError when a
+  // required variable is missing or malformed.
+  const order = map.validate(); // { orderId: string; amount?: number }
+  console.log('Order:', order.orderId);
+}
+//#endregion SearchVariablesAsDto
+
 //#region GetElementInstance
 async function getElementInstanceExample(elementInstanceKey: ElementInstanceKey) {
   const camunda = createCamundaClient();
@@ -402,6 +429,7 @@ void getProcessDefinitionMessageSubscriptionStatisticsExample;
 void getStartProcessFormExample;
 void getVariableExample;
 void searchVariablesExample;
+void searchVariablesAsDtoExample;
 void getElementInstanceExample;
 void searchElementInstancesExample;
 void searchElementInstanceIncidentsExample;

--- a/examples/readme.ts
+++ b/examples/readme.ts
@@ -458,6 +458,35 @@ async function _readmeDeployNode() {
 }
 
 // ---------------------------------------------------------------------------
+// Typed Variable Map (DTO-driven search)
+// ---------------------------------------------------------------------------
+
+async function _readmeTypedVariables(processInstanceKey: ProcessInstanceKey) {
+  const camunda = createCamundaClient();
+  //#region ReadmeTypedVariables
+  // The Zod schema is the DTO: its keys are the variable names to fetch, and its
+  // shape drives validation. Only these declared variables are queried, so memory
+  // stays bound by the DTO — not by the total number of variables on the instance.
+  const OrderVariables = z.object({
+    orderId: z.string(), // required
+    amount: z.number().optional(), // optional
+  });
+
+  const map = await camunda.searchVariablesAsDto(OrderVariables, { processInstanceKey });
+
+  // Lenient access: defensive reads that never throw on missing variables.
+  if (map.has('amount')) {
+    console.log('Amount:', map.get('amount'));
+  }
+
+  // Strict access: returns a fully-typed object, or throws a ZodError when a
+  // required variable is missing or malformed.
+  const order = map.validate(); // { orderId: string; amount?: number }
+  console.log('Order:', order.orderId);
+  //#endregion ReadmeTypedVariables
+}
+
+// ---------------------------------------------------------------------------
 // Testing Patterns
 // ---------------------------------------------------------------------------
 
@@ -659,6 +688,7 @@ void _readmeErrorHandling;
 void _readmeResultClient;
 void _readmeDeployBrowser;
 void _readmeDeployNode;
+void _readmeTypedVariables;
 void _readmeTestingClient;
 void _readmeTestingMock;
 void _readmeWorkerDefaultsEnv;

--- a/external-spec/bundled/rest-api.bundle.json
+++ b/external-spec/bundled/rest-api.bundle.json
@@ -13533,23 +13533,23 @@
         "type": "object",
         "required": [
           "agentInstanceKey",
-          "status",
+          "completionDate",
+          "creationDate",
           "definition",
-          "metrics",
-          "limits",
-          "tools",
           "elementId",
-          "processInstanceKey",
-          "rootProcessInstanceKey",
-          "processDefinitionKey",
+          "elementInstanceKeys",
+          "lastUpdatedDate",
+          "limits",
+          "metrics",
           "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionVersion",
           "processDefinitionVersionTag",
+          "processInstanceKey",
+          "rootProcessInstanceKey",
+          "status",
           "tenantId",
-          "creationDate",
-          "lastUpdatedDate",
-          "completionDate",
-          "elementInstanceKeys"
+          "tools"
         ],
         "properties": {
           "agentInstanceKey": {
@@ -13708,9 +13708,9 @@
         "description": "A tool available to the agent.",
         "type": "object",
         "required": [
-          "name",
           "description",
-          "elementId"
+          "elementId",
+          "name"
         ],
         "properties": {
           "name": {
@@ -13734,8 +13734,8 @@
         "type": "object",
         "required": [
           "inputTokens",
-          "outputTokens",
           "modelCalls",
+          "outputTokens",
           "toolCalls"
         ],
         "properties": {
@@ -13814,8 +13814,8 @@
         "description": "Request to create a new agent instance.",
         "type": "object",
         "required": [
-          "elementInstanceKey",
-          "definition"
+          "definition",
+          "elementInstanceKey"
         ],
         "properties": {
           "elementInstanceKey": {
@@ -13988,37 +13988,37 @@
         "description": "Audit log item.",
         "type": "object",
         "required": [
-          "auditLogKey",
-          "entityKey",
-          "entityType",
-          "operationType",
-          "batchOperationKey",
-          "batchOperationType",
-          "timestamp",
           "actorId",
           "actorType",
           "agentElementId",
-          "tenantId",
-          "result",
+          "auditLogKey",
+          "batchOperationKey",
+          "batchOperationType",
           "category",
-          "processDefinitionId",
-          "processDefinitionKey",
-          "processInstanceKey",
-          "rootProcessInstanceKey",
-          "elementInstanceKey",
-          "jobKey",
-          "userTaskKey",
-          "decisionRequirementsId",
-          "decisionRequirementsKey",
           "decisionDefinitionId",
           "decisionDefinitionKey",
           "decisionEvaluationKey",
+          "decisionRequirementsId",
+          "decisionRequirementsKey",
           "deploymentKey",
+          "elementInstanceKey",
+          "entityDescription",
+          "entityKey",
+          "entityType",
           "formKey",
-          "resourceKey",
+          "jobKey",
+          "operationType",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processInstanceKey",
           "relatedEntityKey",
           "relatedEntityType",
-          "entityDescription"
+          "resourceKey",
+          "result",
+          "rootProcessInstanceKey",
+          "tenantId",
+          "timestamp",
+          "userTaskKey"
         ],
         "properties": {
           "auditLogKey": {
@@ -14949,14 +14949,14 @@
         "type": "object",
         "required": [
           "authorizedComponents",
-          "tenants",
-          "groups",
-          "roles",
-          "salesPlanType",
           "c8Links",
           "canLogout",
           "displayName",
           "email",
+          "groups",
+          "roles",
+          "salesPlanType",
+          "tenants",
           "username"
         ],
         "properties": {
@@ -15075,9 +15075,9 @@
         "required": [
           "ownerId",
           "ownerType",
+          "permissionTypes",
           "resourceId",
-          "resourceType",
-          "permissionTypes"
+          "resourceType"
         ]
       },
       "AuthorizationPropertyBasedRequest": {
@@ -15118,9 +15118,9 @@
         "required": [
           "ownerId",
           "ownerType",
+          "permissionTypes",
           "resourcePropertyName",
-          "resourceType",
-          "permissionTypes"
+          "resourceType"
         ],
         "x-properties-added-in-version": [
           {
@@ -15233,13 +15233,13 @@
       },
       "AuthorizationResult": {
         "required": [
+          "authorizationKey",
           "ownerId",
           "ownerType",
-          "resourceType",
+          "permissionTypes",
           "resourceId",
           "resourcePropertyName",
-          "permissionTypes",
-          "authorizationKey"
+          "resourceType"
         ],
         "type": "object",
         "properties": {
@@ -15591,17 +15591,17 @@
       },
       "BatchOperationResponse": {
         "required": [
+          "actorId",
+          "actorType",
           "batchOperationKey",
           "batchOperationType",
-          "state",
+          "endDate",
+          "errors",
           "operationsCompletedCount",
           "operationsFailedCount",
           "operationsTotalCount",
-          "actorType",
-          "actorId",
-          "errors",
-          "endDate",
-          "startDate"
+          "startDate",
+          "state"
         ],
         "type": "object",
         "properties": {
@@ -15831,13 +15831,13 @@
       "BatchOperationItemResponse": {
         "type": "object",
         "required": [
-          "rootProcessInstanceKey",
           "batchOperationKey",
           "errorMessage",
           "itemKey",
           "operationType",
-          "processedDate",
           "processInstanceKey",
+          "processedDate",
+          "rootProcessInstanceKey",
           "state"
         ],
         "properties": {
@@ -16056,8 +16056,8 @@
           }
         },
         "required": [
-          "targetProcessDefinitionKey",
-          "mappingInstructions"
+          "mappingInstructions",
+          "targetProcessDefinitionKey"
         ]
       },
       "ProcessInstanceModificationBatchOperationRequest": {
@@ -16402,8 +16402,8 @@
         "description": "Cluster variable search response item.",
         "type": "object",
         "required": [
-          "value",
-          "isTruncated"
+          "isTruncated",
+          "value"
         ],
         "allOf": [
           {
@@ -16613,12 +16613,12 @@
         "type": "object",
         "required": [
           "brokers",
+          "clusterId",
           "clusterSize",
-          "partitionsCount",
-          "replicationFactor",
           "gatewayVersion",
           "lastCompletedChangeId",
-          "clusterId"
+          "partitionsCount",
+          "replicationFactor"
         ],
         "properties": {
           "brokers": {
@@ -16697,10 +16697,10 @@
         "description": "Provides information on a broker node.",
         "type": "object",
         "required": [
-          "nodeId",
           "host",
-          "port",
+          "nodeId",
           "partitions",
+          "port",
           "version"
         ],
         "properties": {
@@ -16739,9 +16739,9 @@
         "description": "Provides information on a partition within a broker node.",
         "type": "object",
         "required": [
+          "health",
           "partitionId",
-          "role",
-          "health"
+          "role"
         ],
         "properties": {
           "partitionId": {
@@ -16807,8 +16807,8 @@
       "EvaluateConditionalResult": {
         "type": "object",
         "required": [
-          "processInstances",
           "conditionalEvaluationKey",
+          "processInstances",
           "tenantId"
         ],
         "x-semantic-provider": [
@@ -17339,14 +17339,14 @@
       },
       "EvaluatedDecisionResult": {
         "required": [
-          "decisionDefinitionType",
-          "evaluatedInputs",
-          "matchedRules",
           "decisionDefinitionId",
           "decisionDefinitionKey",
           "decisionDefinitionName",
+          "decisionDefinitionType",
           "decisionDefinitionVersion",
           "decisionEvaluationInstanceKey",
+          "evaluatedInputs",
+          "matchedRules",
           "output",
           "tenantId"
         ],
@@ -17970,11 +17970,11 @@
       },
       "EvaluatedDecisionOutputItem": {
         "required": [
-          "ruleId",
-          "ruleIndex",
           "outputId",
           "outputName",
-          "outputValue"
+          "outputValue",
+          "ruleId",
+          "ruleIndex"
         ],
         "type": "object",
         "description": "The evaluated decision outputs.",
@@ -18357,8 +18357,8 @@
         "type": "object",
         "required": [
           "deploymentKey",
-          "tenantId",
-          "deployments"
+          "deployments",
+          "tenantId"
         ],
         "x-semantic-provider": [
           "deploymentKey"
@@ -18392,10 +18392,10 @@
       "DeploymentMetadataResult": {
         "type": "object",
         "required": [
-          "processDefinition",
           "decisionDefinition",
           "decisionRequirements",
           "form",
+          "processDefinition",
           "resource"
         ],
         "properties": {
@@ -18461,9 +18461,9 @@
         "type": "object",
         "required": [
           "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionVersion",
           "resourceName",
-          "processDefinitionKey",
           "tenantId"
         ],
         "properties": {
@@ -18728,8 +18728,8 @@
       "DeleteResourceResponse": {
         "type": "object",
         "required": [
-          "resourceKey",
-          "batchOperation"
+          "batchOperation",
+          "resourceKey"
         ],
         "properties": {
           "resourceKey": {
@@ -18764,12 +18764,12 @@
       "ResourceResult": {
         "type": "object",
         "required": [
-          "resourceName",
-          "version",
-          "versionTag",
           "resourceId",
+          "resourceKey",
+          "resourceName",
           "tenantId",
-          "resourceKey"
+          "version",
+          "versionTag"
         ],
         "properties": {
           "resourceName": {
@@ -19151,10 +19151,10 @@
         "type": "object",
         "required": [
           "camunda.document.type",
-          "storeId",
-          "documentId",
           "contentHash",
-          "metadata"
+          "documentId",
+          "metadata",
+          "storeId"
         ],
         "properties": {
           "camunda.document.type": {
@@ -19251,8 +19251,8 @@
           {
             "type": "object",
             "required": [
-              "failedDocuments",
-              "createdDocuments"
+              "createdDocuments",
+              "failedDocuments"
             ],
             "properties": {
               "failedDocuments": {
@@ -19352,13 +19352,13 @@
         "description": "Information about the document that is returned in responses.",
         "type": "object",
         "required": [
-          "fileName",
-          "expiresAt",
-          "size",
           "contentType",
           "customProperties",
+          "expiresAt",
+          "fileName",
           "processDefinitionId",
-          "processInstanceKey"
+          "processInstanceKey",
+          "size"
         ],
         "properties": {
           "contentType": {
@@ -19433,8 +19433,8 @@
       "DocumentLink": {
         "type": "object",
         "required": [
-          "url",
-          "expiresAt"
+          "expiresAt",
+          "url"
         ],
         "properties": {
           "url": {
@@ -19745,20 +19745,20 @@
       "ElementInstanceResult": {
         "type": "object",
         "required": [
-          "processDefinitionId",
-          "startDate",
           "elementId",
-          "elementName",
-          "type",
-          "state",
-          "hasIncident",
-          "tenantId",
           "elementInstanceKey",
-          "processInstanceKey",
-          "processDefinitionKey",
-          "rootProcessInstanceKey",
+          "elementName",
           "endDate",
-          "incidentKey"
+          "hasIncident",
+          "incidentKey",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processInstanceKey",
+          "rootProcessInstanceKey",
+          "startDate",
+          "state",
+          "tenantId",
+          "type"
         ],
         "properties": {
           "processDefinitionId": {
@@ -20151,15 +20151,15 @@
         "description": "An element instance waiting state.",
         "type": "object",
         "required": [
-          "waitStateType",
-          "processInstanceKey",
-          "elementInstanceKey",
           "elementId",
+          "elementInstanceKey",
           "elementType",
-          "tenantId",
-          "rootProcessInstanceKey",
           "jobDetails",
-          "messageDetails"
+          "messageDetails",
+          "processInstanceKey",
+          "rootProcessInstanceKey",
+          "tenantId",
+          "waitStateType"
         ],
         "properties": {
           "waitStateType": {
@@ -20251,8 +20251,8 @@
         "type": "object",
         "required": [
           "jobKey",
-          "jobType",
           "jobKind",
+          "jobType",
           "listenerEventType",
           "retries"
         ],
@@ -20297,8 +20297,8 @@
       "MessageWaitStateDetails": {
         "type": "object",
         "required": [
-          "messageName",
-          "correlationKey"
+          "correlationKey",
+          "messageName"
         ],
         "properties": {
           "messageName": {
@@ -20725,11 +20725,11 @@
           "formKey"
         ],
         "required": [
-          "tenantId",
           "formId",
+          "formKey",
           "schema",
-          "version",
-          "formKey"
+          "tenantId",
+          "version"
         ],
         "properties": {
           "tenantId": {
@@ -20854,9 +20854,9 @@
       "CreateGlobalTaskListenerRequest": {
         "type": "object",
         "required": [
+          "eventTypes",
           "id",
-          "type",
-          "eventTypes"
+          "type"
         ],
         "allOf": [
           {
@@ -20872,8 +20872,8 @@
       "UpdateGlobalTaskListenerRequest": {
         "type": "object",
         "required": [
-          "type",
-          "eventTypes"
+          "eventTypes",
+          "type"
         ],
         "allOf": [
           {
@@ -20884,13 +20884,13 @@
       "GlobalTaskListenerResult": {
         "type": "object",
         "required": [
-          "id",
-          "type",
-          "retries",
-          "eventTypes",
           "afterNonGlobal",
+          "eventTypes",
+          "id",
           "priority",
-          "source"
+          "retries",
+          "source",
+          "type"
         ],
         "allOf": [
           {
@@ -21181,9 +21181,9 @@
           }
         },
         "required": [
+          "description",
           "groupId",
-          "name",
-          "description"
+          "name"
         ]
       },
       "GroupUpdateRequest": {
@@ -21224,9 +21224,9 @@
           }
         },
         "required": [
+          "description",
           "groupId",
-          "name",
-          "description"
+          "name"
         ]
       },
       "GroupResult": {
@@ -21252,9 +21252,9 @@
           }
         },
         "required": [
-          "name",
+          "description",
           "groupId",
-          "description"
+          "name"
         ]
       },
       "GroupSearchQuerySortRequest": {
@@ -22237,18 +22237,18 @@
       "IncidentResult": {
         "type": "object",
         "required": [
+          "creationTime",
+          "elementId",
+          "elementInstanceKey",
+          "errorMessage",
+          "errorType",
           "incidentKey",
+          "jobKey",
+          "processDefinitionId",
           "processDefinitionKey",
           "processInstanceKey",
-          "elementInstanceKey",
-          "creationTime",
-          "state",
-          "errorType",
-          "errorMessage",
-          "elementId",
-          "processDefinitionId",
           "rootProcessInstanceKey",
-          "jobKey",
+          "state",
           "tenantId"
         ],
         "properties": {
@@ -22630,8 +22630,8 @@
         "description": "Global job statistics query result.",
         "type": "object",
         "required": [
-          "created",
           "completed",
+          "created",
           "failed",
           "isIncomplete"
         ],
@@ -22726,8 +22726,8 @@
         "description": "Job type statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -22748,10 +22748,10 @@
         "description": "Statistics for a single job type.",
         "type": "object",
         "required": [
-          "jobType",
-          "created",
           "completed",
+          "created",
           "failed",
+          "jobType",
           "workers"
         ],
         "properties": {
@@ -22802,8 +22802,8 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "jobType"
+          "jobType",
+          "to"
         ],
         "properties": {
           "from": {
@@ -22829,8 +22829,8 @@
         "description": "Job worker statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -22851,10 +22851,10 @@
         "description": "Statistics for a single worker within a job type.",
         "type": "object",
         "required": [
-          "worker",
-          "created",
           "completed",
-          "failed"
+          "created",
+          "failed",
+          "worker"
         ],
         "properties": {
           "worker": {
@@ -22898,8 +22898,8 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "jobType"
+          "jobType",
+          "to"
         ],
         "properties": {
           "from": {
@@ -22930,8 +22930,8 @@
         "description": "Job time-series statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -22952,10 +22952,10 @@
         "description": "Aggregated job metrics for a single time bucket.",
         "type": "object",
         "required": [
-          "time",
-          "created",
           "completed",
-          "failed"
+          "created",
+          "failed",
+          "time"
         ],
         "properties": {
           "time": {
@@ -23000,8 +23000,8 @@
         "type": "object",
         "required": [
           "from",
-          "to",
-          "jobType"
+          "jobType",
+          "to"
         ],
         "properties": {
           "from": {
@@ -23043,8 +23043,8 @@
         "description": "Job error statistics query result.",
         "type": "object",
         "required": [
-          "page",
-          "items"
+          "items",
+          "page"
         ],
         "allOf": [
           {
@@ -23150,9 +23150,9 @@
           }
         },
         "required": [
-          "type",
           "maxJobsToActivate",
-          "timeout"
+          "timeout",
+          "type"
         ],
         "x-properties-added-in-version": [
           {
@@ -23185,26 +23185,26 @@
         ],
         "type": "object",
         "required": [
-          "type",
-          "processDefinitionId",
-          "processDefinitionVersion",
-          "elementId",
           "customHeaders",
-          "worker",
-          "retries",
           "deadline",
-          "variables",
-          "tenantId",
-          "jobKey",
-          "processInstanceKey",
-          "processDefinitionKey",
+          "elementId",
           "elementInstanceKey",
+          "jobKey",
           "kind",
           "listenerEventType",
+          "priority",
+          "processDefinitionId",
+          "processDefinitionKey",
+          "processDefinitionVersion",
+          "processInstanceKey",
+          "retries",
           "rootProcessInstanceKey",
           "tags",
+          "tenantId",
+          "type",
           "userTask",
-          "priority"
+          "variables",
+          "worker"
         ],
         "properties": {
           "type": {
@@ -23364,11 +23364,11 @@
       },
       "UserTaskProperties": {
         "required": [
+          "action",
+          "assignee",
           "candidateGroups",
           "candidateUsers",
           "changedAttributes",
-          "action",
-          "assignee",
           "dueDate",
           "followUpDate",
           "formKey",
@@ -23733,31 +23733,31 @@
       "JobSearchResult": {
         "type": "object",
         "required": [
+          "creationTime",
           "customHeaders",
+          "deadline",
+          "deniedReason",
           "elementId",
           "elementInstanceKey",
+          "endTime",
+          "errorCode",
+          "errorMessage",
           "hasFailedWithRetriesLeft",
+          "isDenied",
           "jobKey",
           "kind",
+          "lastUpdateTime",
           "listenerEventType",
           "priority",
           "processDefinitionId",
           "processDefinitionKey",
           "processInstanceKey",
           "retries",
+          "rootProcessInstanceKey",
           "state",
           "tenantId",
           "type",
-          "worker",
-          "rootProcessInstanceKey",
-          "creationTime",
-          "deadline",
-          "deniedReason",
-          "endTime",
-          "errorCode",
-          "errorMessage",
-          "isDenied",
-          "lastUpdateTime"
+          "worker"
         ],
         "properties": {
           "customHeaders": {
@@ -25393,10 +25393,10 @@
         "description": "The response of a license request.",
         "type": "object",
         "required": [
-          "validLicense",
-          "licenseType",
+          "expiresAt",
           "isCommercial",
-          "expiresAt"
+          "licenseType",
+          "validLicense"
         ],
         "properties": {
           "validLicense": {
@@ -25510,8 +25510,8 @@
         "required": [
           "claimName",
           "claimValue",
-          "name",
-          "mappingRuleId"
+          "mappingRuleId",
+          "name"
         ]
       },
       "MappingRuleCreateResult": {
@@ -25577,8 +25577,8 @@
         "required": [
           "claimName",
           "claimValue",
-          "name",
-          "mappingRuleId"
+          "mappingRuleId",
+          "name"
         ]
       },
       "MappingRuleSearchQuerySortRequest": {
@@ -25693,9 +25693,9 @@
         ],
         "type": "object",
         "required": [
-          "tenantId",
           "messageKey",
-          "processInstanceKey"
+          "processInstanceKey",
+          "tenantId"
         ],
         "properties": {
           "tenantId": {
@@ -25773,8 +25773,8 @@
         ],
         "type": "object",
         "required": [
-          "tenantId",
-          "messageKey"
+          "messageKey",
+          "tenantId"
         ],
         "properties": {
           "tenantId": {
@@ -25818,11 +25818,9 @@
       "MessageSubscriptionResult": {
         "type": "object",
         "required": [
-          "rootProcessInstanceKey",
           "correlationKey",
           "elementId",
           "elementInstanceKey",
-          "toolProperties",
           "inboundConnectorType",
           "lastUpdatedDate",
           "messageName",
@@ -25834,8 +25832,10 @@
           "processDefinitionName",
           "processDefinitionVersion",
           "processInstanceKey",
+          "rootProcessInstanceKey",
           "tenantId",
-          "toolName"
+          "toolName",
+          "toolProperties"
         ],
         "properties": {
           "messageSubscriptionKey": {
@@ -26265,16 +26265,16 @@
           "correlationKey",
           "correlationTime",
           "elementId",
+          "elementInstanceKey",
           "messageKey",
           "messageName",
           "partitionId",
           "processDefinitionId",
+          "processDefinitionKey",
           "processInstanceKey",
-          "subscriptionKey",
-          "tenantId",
           "rootProcessInstanceKey",
-          "elementInstanceKey",
-          "processDefinitionKey"
+          "subscriptionKey",
+          "tenantId"
         ],
         "properties": {
           "correlationKey": {
@@ -26725,11 +26725,11 @@
         "description": "A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457). There may be additional properties specific to the problem type.\n",
         "type": "object",
         "required": [
-          "type",
-          "title",
-          "status",
           "detail",
-          "instance"
+          "instance",
+          "status",
+          "title",
+          "type"
         ],
         "properties": {
           "type": {
@@ -26897,14 +26897,14 @@
       "ProcessDefinitionResult": {
         "type": "object",
         "required": [
-          "processDefinitionKey",
+          "hasStartForm",
           "name",
-          "resourceName",
-          "version",
-          "versionTag",
           "processDefinitionId",
+          "processDefinitionKey",
+          "resourceName",
           "tenantId",
-          "hasStartForm"
+          "version",
+          "versionTag"
         ],
         "properties": {
           "name": {
@@ -27340,13 +27340,13 @@
           }
         },
         "required": [
+          "activeInstancesWithIncidentCount",
+          "activeInstancesWithoutIncidentCount",
           "processDefinitionId",
           "processDefinitionKey",
-          "tenantId",
           "processDefinitionName",
           "processDefinitionVersion",
-          "activeInstancesWithIncidentCount",
-          "activeInstancesWithoutIncidentCount"
+          "tenantId"
         ]
       },
       "ProcessDefinitionInstanceVersionStatisticsQuerySortRequest": {
@@ -27634,14 +27634,14 @@
           "processInstanceKey"
         ],
         "required": [
+          "businessId",
           "processDefinitionId",
           "processDefinitionKey",
           "processDefinitionVersion",
-          "tenantId",
-          "variables",
           "processInstanceKey",
           "tags",
-          "businessId"
+          "tenantId",
+          "variables"
         ],
         "type": "object",
         "properties": {
@@ -28135,22 +28135,22 @@
         "description": "Process instance search response item.",
         "type": "object",
         "required": [
+          "businessId",
+          "endDate",
+          "hasIncident",
+          "parentElementInstanceKey",
+          "parentProcessInstanceKey",
           "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionName",
           "processDefinitionVersion",
           "processDefinitionVersionTag",
-          "startDate",
-          "endDate",
-          "state",
-          "hasIncident",
-          "tenantId",
           "processInstanceKey",
-          "processDefinitionKey",
-          "parentProcessInstanceKey",
-          "parentElementInstanceKey",
           "rootProcessInstanceKey",
+          "startDate",
+          "state",
           "tags",
-          "businessId"
+          "tenantId"
         ],
         "properties": {
           "processDefinitionId": {
@@ -28338,9 +28338,9 @@
       "ProcessInstanceCallHierarchyEntry": {
         "type": "object",
         "required": [
-          "processInstanceKey",
           "processDefinitionKey",
-          "processDefinitionName"
+          "processDefinitionName",
+          "processInstanceKey"
         ],
         "properties": {
           "processInstanceKey": {
@@ -28385,11 +28385,11 @@
         "description": "Process instance sequence flow result.",
         "type": "object",
         "required": [
-          "rootProcessInstanceKey",
           "elementId",
           "processDefinitionId",
           "processDefinitionKey",
           "processInstanceKey",
+          "rootProcessInstanceKey",
           "sequenceFlowId",
           "tenantId"
         ],
@@ -28491,8 +28491,8 @@
           }
         },
         "required": [
-          "targetProcessDefinitionKey",
-          "mappingInstructions"
+          "mappingInstructions",
+          "targetProcessDefinitionKey"
         ]
       },
       "MigrateProcessInstanceMappingInstruction": {
@@ -28919,8 +28919,8 @@
           }
         },
         "required": [
-          "roleId",
-          "name"
+          "name",
+          "roleId"
         ]
       },
       "RoleCreateResult": {
@@ -28945,9 +28945,9 @@
           }
         },
         "required": [
-          "roleId",
+          "description",
           "name",
-          "description"
+          "roleId"
         ]
       },
       "RoleUpdateRequest": {
@@ -28988,9 +28988,9 @@
           }
         },
         "required": [
-          "roleId",
+          "description",
           "name",
-          "description"
+          "roleId"
         ]
       },
       "RoleResult": {
@@ -29016,9 +29016,9 @@
           }
         },
         "required": [
-          "roleId",
+          "description",
           "name",
-          "description"
+          "roleId"
         ]
       },
       "RoleSearchQuerySortRequest": {
@@ -29504,10 +29504,10 @@
         "description": "Pagination information about the search results.",
         "type": "object",
         "required": [
-          "totalItems",
+          "endCursor",
           "hasMoreTotalItems",
           "startCursor",
-          "endCursor"
+          "totalItems"
         ],
         "x-semantic-provider": [
           "startCursor",
@@ -29586,8 +29586,8 @@
       "SignalBroadcastResult": {
         "type": "object",
         "required": [
-          "tenantId",
-          "signalKey"
+          "signalKey",
+          "tenantId"
         ],
         "x-semantic-provider": [
           "signalKey"
@@ -29625,8 +29625,8 @@
       },
       "UsageMetricsResponse": {
         "required": [
-          "tenants",
-          "activeTenants"
+          "activeTenants",
+          "tenants"
         ],
         "type": "object",
         "allOf": [
@@ -29658,9 +29658,9 @@
       },
       "UsageMetricsResponseItem": {
         "required": [
-          "processInstances",
+          "assignees",
           "decisionInstances",
-          "assignees"
+          "processInstances"
         ],
         "type": "object",
         "properties": {
@@ -29685,11 +29685,11 @@
         "description": "Envelope for all system configuration sections. Each property\nrepresents a feature area.\n",
         "type": "object",
         "required": [
-          "jobMetrics",
+          "authentication",
+          "cloud",
           "components",
           "deployment",
-          "authentication",
-          "cloud"
+          "jobMetrics"
         ],
         "properties": {
           "jobMetrics": {
@@ -29733,10 +29733,10 @@
         "required": [
           "enabled",
           "exportInterval",
-          "maxWorkerNameLength",
           "maxJobTypeLength",
           "maxTenantIdLength",
-          "maxUniqueKeys"
+          "maxUniqueKeys",
+          "maxWorkerNameLength"
         ],
         "properties": {
           "enabled": {
@@ -29896,8 +29896,8 @@
           }
         },
         "required": [
-          "tenantId",
-          "name"
+          "name",
+          "tenantId"
         ]
       },
       "TenantCreateResult": {
@@ -29927,9 +29927,9 @@
           }
         },
         "required": [
-          "tenantId",
+          "description",
           "name",
-          "description"
+          "tenantId"
         ]
       },
       "TenantUpdateRequest": {
@@ -29971,9 +29971,9 @@
           }
         },
         "required": [
-          "tenantId",
+          "description",
           "name",
-          "description"
+          "tenantId"
         ]
       },
       "TenantResult": {
@@ -30001,9 +30001,9 @@
           }
         },
         "required": [
-          "tenantId",
+          "description",
           "name",
-          "description"
+          "tenantId"
         ]
       },
       "TenantSearchQuerySortRequest": {
@@ -30627,30 +30627,30 @@
       "UserTaskResult": {
         "type": "object",
         "required": [
-          "tenantId",
-          "userTaskKey",
-          "name",
-          "processInstanceKey",
-          "rootProcessInstanceKey",
-          "processDefinitionKey",
-          "elementInstanceKey",
-          "processDefinitionId",
-          "processName",
-          "state",
+          "assignee",
           "candidateGroups",
           "candidateUsers",
-          "elementId",
+          "completionDate",
           "creationDate",
           "customHeaders",
-          "priority",
-          "tags",
-          "assignee",
-          "completionDate",
           "dueDate",
+          "elementId",
+          "elementInstanceKey",
           "externalFormReference",
           "followUpDate",
+          "formKey",
+          "name",
+          "priority",
+          "processDefinitionId",
+          "processDefinitionKey",
           "processDefinitionVersion",
-          "formKey"
+          "processInstanceKey",
+          "processName",
+          "rootProcessInstanceKey",
+          "state",
+          "tags",
+          "tenantId",
+          "userTaskKey"
         ],
         "properties": {
           "name": {
@@ -31280,8 +31280,8 @@
           }
         },
         "required": [
-          "username",
-          "password"
+          "password",
+          "username"
         ]
       },
       "UserCreateResult": {
@@ -31310,9 +31310,9 @@
           }
         },
         "required": [
-          "username",
+          "email",
           "name",
-          "email"
+          "username"
         ]
       },
       "UserUpdateRequest": {
@@ -31355,9 +31355,9 @@
           }
         },
         "required": [
-          "username",
+          "email",
           "name",
-          "email"
+          "username"
         ]
       },
       "UserResult": {
@@ -31383,9 +31383,9 @@
           }
         },
         "required": [
-          "username",
+          "email",
           "name",
-          "email"
+          "username"
         ]
       },
       "UserSearchQuerySortRequest": {
@@ -31660,10 +31660,10 @@
         "required": [
           "name",
           "processInstanceKey",
-          "tenantId",
-          "variableKey",
+          "rootProcessInstanceKey",
           "scopeKey",
-          "rootProcessInstanceKey"
+          "tenantId",
+          "variableKey"
         ],
         "properties": {
           "name": {

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -31,6 +31,7 @@ import { BackpressureManager } from '../runtime/backpressure';
 import {
   type AnyVariableSchema,
   collectTypedVariables,
+  createVariableSearchFetchPage,
   type VariableMap,
   variableNamesFromSchema,
 } from '../runtime/typedVariables';
@@ -39,7 +40,6 @@ import type {
   ScopeKey,
   TenantId,
   VariableFilter,
-  VariableSearchResult,
 } from '../gen/types.gen';
 import { JobWorker, type JobWorkerConfig } from '../runtime/jobWorker';
 import { enrichActivatedJob, EnrichedActivatedJob } from '../runtime/jobActions';
@@ -16913,29 +16913,12 @@ export class CamundaClient {
         // once and paging can stop as soon as all are found. Otherwise we page to exhaustion so a
         // same-name/different-scope collision on a later page surfaces as a VariableScopeCollisionError.
         singleScope: Boolean(options.scopeKey),
-        fetchPage: async (after) => {
-          // Honour cancellation of the returned CancelablePromise between pages.
-          signal.throwIfAborted();
-          const input = {
-            filter,
-            page: after ? { after, limit } : { limit },
-            // Full values are required to bind the DTO; never truncate.
-            truncateValues: false,
-          };
-          const pending = this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
-          // Propagate outer cancellation to the in-flight paging request so it aborts too.
-          const onAbort = () => pending.cancel();
-          signal.addEventListener('abort', onAbort, { once: true });
-          const result = await pending.finally(() =>
-            signal.removeEventListener('abort', onAbort)
-          );
-          const items = (result?.items ?? []).map((item: VariableSearchResult) => ({
-            name: item.name,
-            value: item.value,
-            scopeKey: String(item.scopeKey),
-          }));
-          return { items, endCursor: result?.page?.endCursor ?? null };
-        },
+        fetchPage: createVariableSearchFetchPage({
+          filter,
+          limit,
+          signal,
+          search: (input) => this.searchVariables(input, { consistency: { waitUpToMs: 0 } }),
+        }),
       });
     });
   }

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -28,6 +28,12 @@ import {
 } from '../runtime/retry';
 import { normalizeError } from '../runtime/errors';
 import { BackpressureManager } from '../runtime/backpressure';
+import {
+  type AnyVariableSchema,
+  collectTypedVariables,
+  type VariableMap,
+  variableNamesFromSchema,
+} from '../runtime/typedVariables';
 import { JobWorker, type JobWorkerConfig } from '../runtime/jobWorker';
 import { enrichActivatedJob, EnrichedActivatedJob } from '../runtime/jobActions';
 import { ThreadedJobWorker, type ThreadedJobWorkerConfig } from '../runtime/threadedJobWorker';
@@ -16841,6 +16847,77 @@ export class CamundaClient {
         ...(options?.tenantId ? { tenantId: options.tenantId } : {}),
       } as any;
       return this.createDeployment(payload);
+    });
+  }
+
+  /**
+   * Search for process variables and bind them to a Zod schema (the DTO).
+   *
+   * The schema's keys are the exact variable names to fetch; its shape drives validation. Only
+   * those declared variables are queried (via a `name $in [...]` filter), so memory stays bound
+   * by the DTO shape rather than the total number of variables on the instance. Results are
+   * paged internally until every declared variable is found or the result set is exhausted.
+   *
+   * Returns a {@link VariableMap} offering lenient access (`has` / `get`) and a strict
+   * `validate()` that parses the collected values against the schema — returning a fully-typed
+   * object or throwing a `ZodError` when a required variable is missing or malformed.
+   *
+   * @param schema A Zod object schema declaring the variables to fetch.
+   * @param options Query scope. `processInstanceKey` is required; `scopeKey` narrows to a single
+   *   element-instance scope, `tenantId` filters by tenant, and `pageSize` tunes the page limit.
+   * @throws {VariableScopeCollisionError} when a declared variable is found at more than one
+   *   scope and no `scopeKey` was provided to disambiguate.
+   * @throws {VariableDeserializationError} when a variable's value is not valid JSON.
+   *
+   * @example
+   * ```ts
+   * import { z } from 'zod';
+   * const OrderVariables = z.object({ orderId: z.string(), amount: z.number().optional() });
+   * const map = await client.searchVariablesAsDto(OrderVariables, { processInstanceKey });
+   * if (map.has('amount')) console.log(map.get('amount'));
+   * const order = map.validate(); // { orderId: string; amount?: number }
+   * ```
+   */
+  searchVariablesAsDto<TSchema extends AnyVariableSchema>(
+    schema: TSchema,
+    options: {
+      processInstanceKey: string;
+      scopeKey?: string;
+      tenantId?: string;
+      pageSize?: number;
+    }
+  ): CancelablePromise<VariableMap<TSchema>> {
+    return toCancelable(async (_signal) => {
+      if (!options?.processInstanceKey) {
+        throw new Error('searchVariablesAsDto requires options.processInstanceKey');
+      }
+      const names = variableNamesFromSchema(schema);
+      const limit = options.pageSize && options.pageSize > 0 ? options.pageSize : 100;
+      const filter: Record<string, unknown> = {
+        name: { $in: names },
+        processInstanceKey: options.processInstanceKey,
+      };
+      if (options.scopeKey) filter.scopeKey = options.scopeKey;
+      if (options.tenantId) filter.tenantId = options.tenantId;
+
+      return collectTypedVariables({
+        schema,
+        fetchPage: async (after) => {
+          const input = {
+            filter,
+            page: after ? { after, limit } : { limit },
+            // Full values are required to bind the DTO; never truncate.
+            truncateValues: false,
+          };
+          const result = await this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
+          const items = (result?.items ?? []).map((item: any) => ({
+            name: item.name,
+            value: item.value,
+            scopeKey: String(item.scopeKey),
+          }));
+          return { items, endCursor: result?.page?.endCursor ?? null };
+        },
+      });
     });
   }
 }

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -38,6 +38,7 @@ import type {
   ProcessInstanceKey,
   ScopeKey,
   TenantId,
+  VariableFilter,
   VariableSearchResult,
 } from '../gen/types.gen';
 import { JobWorker, type JobWorkerConfig } from '../runtime/jobWorker';
@@ -16893,13 +16894,13 @@ export class CamundaClient {
       pageSize?: number;
     }
   ): CancelablePromise<VariableMap<TSchema>> {
-    return toCancelable(async (_signal) => {
+    return toCancelable(async (signal) => {
       if (!options?.processInstanceKey) {
         throw new Error('searchVariablesAsDto requires options.processInstanceKey');
       }
       const names = variableNamesFromSchema(schema);
       const limit = options.pageSize && options.pageSize > 0 ? options.pageSize : 100;
-      const filter: Record<string, unknown> = {
+      const filter: VariableFilter = {
         name: { $in: names },
         processInstanceKey: options.processInstanceKey,
       };
@@ -16913,13 +16914,21 @@ export class CamundaClient {
         // same-name/different-scope collision on a later page surfaces as a VariableScopeCollisionError.
         singleScope: Boolean(options.scopeKey),
         fetchPage: async (after) => {
+          // Honour cancellation of the returned CancelablePromise between pages.
+          signal.throwIfAborted();
           const input = {
             filter,
             page: after ? { after, limit } : { limit },
             // Full values are required to bind the DTO; never truncate.
             truncateValues: false,
           };
-          const result = await this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
+          const pending = this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
+          // Propagate outer cancellation to the in-flight paging request so it aborts too.
+          const onAbort = () => pending.cancel();
+          signal.addEventListener('abort', onAbort, { once: true });
+          const result = await pending.finally(() =>
+            signal.removeEventListener('abort', onAbort)
+          );
           const items = (result?.items ?? []).map((item: VariableSearchResult) => ({
             name: item.name,
             value: item.value,

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -16872,6 +16872,10 @@ export class CamundaClient {
    * @param schema A Zod object schema declaring the variables to fetch.
    * @param options Query scope. `processInstanceKey` is required; `scopeKey` narrows to a single
    *   element-instance scope, `tenantId` filters by tenant, and `pageSize` tunes the page limit.
+   *   `consistency` controls eventual-consistency tolerance for the underlying `searchVariables`
+   *   calls: it defaults to `{ waitUpToMs: 0 }` (no waiting), but a non-zero `waitUpToMs` makes the
+   *   paging calls poll until the data is consistent, avoiding intermittent missing variables /
+   *   `ZodError` on a freshly-updated instance.
    * @throws {VariableScopeCollisionError} when a declared variable is found at more than one
    *   scope and no `scopeKey` was provided to disambiguate.
    * @throws {VariableDeserializationError} when a variable's value is not valid JSON.
@@ -16892,6 +16896,7 @@ export class CamundaClient {
       scopeKey?: ScopeKey;
       tenantId?: TenantId;
       pageSize?: number;
+      consistency?: { waitUpToMs: number; pollIntervalMs?: number };
     }
   ): CancelablePromise<VariableMap<TSchema>> {
     return toCancelable(async (signal) => {
@@ -16907,6 +16912,10 @@ export class CamundaClient {
       if (options.scopeKey) filter.scopeKey = options.scopeKey;
       if (options.tenantId) filter.tenantId = options.tenantId;
 
+      // Default to no eventual-consistency wait, but let callers opt into polling for a stable
+      // snapshot when querying a freshly-updated instance.
+      const consistency = options.consistency ?? { waitUpToMs: 0 };
+
       return collectTypedVariables({
         schema,
         // A single scopeKey restricts results to one scope, so each declared name appears at most
@@ -16917,7 +16926,7 @@ export class CamundaClient {
           filter,
           limit,
           signal,
-          search: (input) => this.searchVariables(input, { consistency: { waitUpToMs: 0 } }),
+          search: (input) => this.searchVariables(input, { consistency }),
         }),
       });
     });

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -34,6 +34,12 @@ import {
   type VariableMap,
   variableNamesFromSchema,
 } from '../runtime/typedVariables';
+import type {
+  ProcessInstanceKey,
+  ScopeKey,
+  TenantId,
+  VariableSearchResult,
+} from '../gen/types.gen';
 import { JobWorker, type JobWorkerConfig } from '../runtime/jobWorker';
 import { enrichActivatedJob, EnrichedActivatedJob } from '../runtime/jobActions';
 import { ThreadedJobWorker, type ThreadedJobWorkerConfig } from '../runtime/threadedJobWorker';
@@ -16881,9 +16887,9 @@ export class CamundaClient {
   searchVariablesAsDto<TSchema extends AnyVariableSchema>(
     schema: TSchema,
     options: {
-      processInstanceKey: string;
-      scopeKey?: string;
-      tenantId?: string;
+      processInstanceKey: ProcessInstanceKey;
+      scopeKey?: ScopeKey;
+      tenantId?: TenantId;
       pageSize?: number;
     }
   ): CancelablePromise<VariableMap<TSchema>> {
@@ -16902,6 +16908,10 @@ export class CamundaClient {
 
       return collectTypedVariables({
         schema,
+        // A single scopeKey restricts results to one scope, so each declared name appears at most
+        // once and paging can stop as soon as all are found. Otherwise we page to exhaustion so a
+        // same-name/different-scope collision on a later page surfaces as a VariableScopeCollisionError.
+        singleScope: Boolean(options.scopeKey),
         fetchPage: async (after) => {
           const input = {
             filter,
@@ -16910,7 +16920,7 @@ export class CamundaClient {
             truncateValues: false,
           };
           const result = await this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
-          const items = (result?.items ?? []).map((item: any) => ({
+          const items = (result?.items ?? []).map((item: VariableSearchResult) => ({
             name: item.name,
             value: item.value,
             scopeKey: String(item.scopeKey),

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -20,6 +20,7 @@ import {
 } from '../runtime/telemetry';
 import { ValidationManager } from '../runtime/validationManager';
 import type { Client } from '../gen/client/types.gen';
+import type { ProcessInstanceKey, ScopeKey, TenantId, VariableFilter } from '../gen/types.gen';
 import {
   executeWithHttpRetry,
   defaultHttpClassifier,
@@ -35,12 +36,6 @@ import {
   type VariableMap,
   variableNamesFromSchema,
 } from '../runtime/typedVariables';
-import type {
-  ProcessInstanceKey,
-  ScopeKey,
-  TenantId,
-  VariableFilter,
-} from '../gen/types.gen';
 import { JobWorker, type JobWorkerConfig } from '../runtime/jobWorker';
 import { enrichActivatedJob, EnrichedActivatedJob } from '../runtime/jobActions';
 import { ThreadedJobWorker, type ThreadedJobWorkerConfig } from '../runtime/threadedJobWorker';
@@ -16926,7 +16921,13 @@ export class CamundaClient {
           filter,
           limit,
           signal,
-          search: (input) => this.searchVariables(input, { consistency }),
+          search: (input) => {
+            // Only apply eventual consistency polling to the first search (no cursor).
+            // Pagination searches should return immediately with whatever results are available,
+            // including empty results, which are valid when there are no more pages.
+            const useConsistency = input.page.after === undefined ? consistency : { waitUpToMs: 0 };
+            return this.searchVariables(input, { consistency: useConsistency });
+          },
         }),
       });
     });

--- a/src/gen/CamundaClient.ts
+++ b/src/gen/CamundaClient.ts
@@ -16907,27 +16907,22 @@ export class CamundaClient {
       if (options.scopeKey) filter.scopeKey = options.scopeKey;
       if (options.tenantId) filter.tenantId = options.tenantId;
 
-      // Default to no eventual-consistency wait, but let callers opt into polling for a stable
-      // snapshot when querying a freshly-updated instance.
-      const consistency = options.consistency ?? { waitUpToMs: 0 };
-
       return collectTypedVariables({
         schema,
         // A single scopeKey restricts results to one scope, so each declared name appears at most
         // once and paging can stop as soon as all are found. Otherwise we page to exhaustion so a
         // same-name/different-scope collision on a later page surfaces as a VariableScopeCollisionError.
         singleScope: Boolean(options.scopeKey),
+        // Eventual-consistency waiting happens at the collection level: re-read until every declared
+        // variable is visible or the budget expires. The per-page search never waits — a paging read
+        // that legitimately returns 0 items must not block, and waiting on the first search alone
+        // settles on a partial result (its success condition is merely "any matching variable").
+        consistency: options.consistency,
         fetchPage: createVariableSearchFetchPage({
           filter,
           limit,
           signal,
-          search: (input) => {
-            // Only apply eventual consistency polling to the first search (no cursor).
-            // Pagination searches should return immediately with whatever results are available,
-            // including empty results, which are valid when there are no more pages.
-            const useConsistency = input.page.after === undefined ? consistency : { waitUpToMs: 0 };
-            return this.searchVariables(input, { consistency: useConsistency });
-          },
+          search: (input) => this.searchVariables(input, { consistency: { waitUpToMs: 0 } }),
         }),
       });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,18 @@ export type {
   ThreadedJobWorkerConfig,
 } from './runtime/threadedJobWorker';
 export type { ThreadPool } from './runtime/threadPool';
+// Typed variable map (DTO-driven variable search)
+export {
+  type AnyVariableSchema,
+  type TypedVariableItem,
+  type TypedVariablePage,
+  TypedVariablesError,
+  VariableCollector,
+  VariableDeserializationError,
+  VariableMap,
+  VariableScopeCollisionError,
+  variableNamesFromSchema,
+} from './runtime/typedVariables';
 // Runtime types used in public signatures
 export type { AuthStrategy, CamundaConfig, ValidationMode } from './runtime/unifiedConfiguration';
 // eventualPoll unified with result mode; no separate export

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export type { ThreadPool } from './runtime/threadPool';
 // Typed variable map (DTO-driven variable search)
 export {
   type AnyVariableSchema,
+  collectTypedVariables,
   type TypedVariableItem,
   type TypedVariablePage,
   TypedVariablesError,

--- a/src/runtime/typedVariables.ts
+++ b/src/runtime/typedVariables.ts
@@ -67,9 +67,20 @@ export interface TypedVariablePage {
 /** Any Zod object schema; used as the DTO that declares the variables to fetch. */
 export type AnyVariableSchema = z.ZodObject<any>;
 
-/** The declared variable names, in declaration order. These key the `name $in [...]` filter. */
+/**
+ * The declared variable names, in declaration order. These key the `name $in [...]` filter.
+ *
+ * Guards against non-schema inputs (e.g. a JS caller, or an `any` cast) so the failure is a clear,
+ * actionable error rather than an opaque `Cannot read properties of undefined` deep in paging.
+ */
 export function variableNamesFromSchema(schema: AnyVariableSchema): string[] {
-  return Object.keys(schema.shape);
+  const shape = schema == null ? undefined : schema.shape;
+  if (shape == null || typeof shape !== 'object') {
+    throw new TypedVariablesError(
+      'A Zod object schema is required: its keys declare the variable names to fetch.'
+    );
+  }
+  return Object.keys(shape);
 }
 
 /**
@@ -235,4 +246,68 @@ export async function collectTypedVariables<TSchema extends AnyVariableSchema>(p
   }
 
   return new VariableMap(collector.build(), params.schema);
+}
+
+/**
+ * A cancelable in-flight request, mirroring the generated `CancelablePromise` (a `Promise` with an
+ * extra `cancel()`). Kept structural here so the runtime core stays free of generated-type imports.
+ */
+export interface CancelableRequest<T> extends PromiseLike<T> {
+  cancel(): void;
+}
+
+/** The subset of the variable search response the page fetcher reads. */
+export interface VariableSearchPageResponse {
+  items?: ReadonlyArray<{ name: string; value: string; scopeKey: unknown }> | null;
+  page?: { endCursor?: string | null } | null;
+}
+
+/** The request input the page fetcher builds for each page. */
+export interface VariableSearchPageInput<TFilter> {
+  filter: TFilter;
+  page: { after?: string; limit: number };
+  truncateValues: boolean;
+}
+
+/**
+ * Build the `fetchPage` callback for {@link collectTypedVariables} that drives the variable search
+ * API. For each page it: aborts early if the outer signal is already aborted, issues the request
+ * with the declared-name filter and `truncateValues: false` (full values are required to bind the
+ * DTO), forwards outer cancellation to the in-flight request via its `cancel()`, and maps the raw
+ * items into {@link TypedVariableItem}s.
+ *
+ * Transport is injected as `search`, so the input construction and cancellation propagation are
+ * unit-testable without a live client.
+ */
+export function createVariableSearchFetchPage<TFilter>(params: {
+  filter: TFilter;
+  limit: number;
+  signal: AbortSignal;
+  search: (
+    input: VariableSearchPageInput<TFilter>
+  ) => CancelableRequest<VariableSearchPageResponse>;
+}): (after: string | undefined) => Promise<TypedVariablePage> {
+  const { filter, limit, signal, search } = params;
+  return async (after) => {
+    // Honour cancellation of the returned CancelablePromise between pages.
+    signal.throwIfAborted();
+    const input: VariableSearchPageInput<TFilter> = {
+      filter,
+      page: after ? { after, limit } : { limit },
+      truncateValues: false,
+    };
+    const pending = search(input);
+    // Propagate outer cancellation to the in-flight paging request so it aborts too.
+    const onAbort = () => pending.cancel();
+    signal.addEventListener('abort', onAbort, { once: true });
+    const result = await Promise.resolve(pending).finally(() =>
+      signal.removeEventListener('abort', onAbort)
+    );
+    const items = (result?.items ?? []).map((item) => ({
+      name: item.name,
+      value: item.value,
+      scopeKey: String(item.scopeKey),
+    }));
+    return { items, endCursor: result?.page?.endCursor ?? null };
+  };
 }

--- a/src/runtime/typedVariables.ts
+++ b/src/runtime/typedVariables.ts
@@ -1,0 +1,218 @@
+// Pure (I/O-free) core of the DTO-driven typed variable map feature.
+//
+// A Zod object schema is the DTO: its keys are the exact wire variable names to query for, and
+// its field shape drives validation. This mirrors the C# (reflection) and Python (Pydantic)
+// SDKs while staying idiomatic to TypeScript — the SDK already depends on Zod for request and
+// response validation.
+//
+// Keeping the paging collapse, scope-collision detection, and value deserialization free of HTTP
+// makes the memory-bound behaviour directly unit-testable. The HTTP wiring lives in the client
+// method `searchVariablesAsDto`, which injects a `fetchPage` callback.
+import type { z } from 'zod';
+
+/** Base class for all typed-variable errors, so callers can catch the whole family. */
+export class TypedVariablesError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'TypedVariablesError';
+  }
+}
+
+/**
+ * Raised when a declared variable name is observed at more than one scope (for example a local
+ * variable shadowing a process-level variable). The result would be ambiguous, so the search
+ * fails loudly rather than silently picking one. Pass an explicit `scopeKey` to disambiguate.
+ */
+export class VariableScopeCollisionError extends TypedVariablesError {
+  constructor(
+    public readonly variableName: string,
+    public readonly scopeKeys: readonly string[]
+  ) {
+    super(
+      `Variable '${variableName}' was found at more than one scope (${scopeKeys.join(
+        ', '
+      )}). Pass an explicit scopeKey to disambiguate.`
+    );
+    this.name = 'VariableScopeCollisionError';
+  }
+}
+
+/** Raised when a variable's serialized value is not valid JSON. */
+export class VariableDeserializationError extends TypedVariablesError {
+  constructor(
+    public readonly variableName: string,
+    options?: { cause?: unknown }
+  ) {
+    super(`Variable '${variableName}' could not be deserialized from its JSON value.`, options);
+    this.name = 'VariableDeserializationError';
+  }
+}
+
+/** A single variable item from a search page (the subset the collector needs). */
+export interface TypedVariableItem {
+  name: string;
+  /** The variable value, serialized as JSON (the wire representation). */
+  value: string;
+  /** The scope key the variable is directly defined in. */
+  scopeKey: string;
+}
+
+/** One page of variable search results. */
+export interface TypedVariablePage {
+  items: readonly TypedVariableItem[];
+  /** Cursor for the next page, or `null` when there are no more pages. */
+  endCursor: string | null;
+}
+
+/** Any Zod object schema; used as the DTO that declares the variables to fetch. */
+export type AnyVariableSchema = z.ZodObject<any>;
+
+/** The declared variable names, in declaration order. These key the `name $in [...]` filter. */
+export function variableNamesFromSchema(schema: AnyVariableSchema): string[] {
+  return Object.keys(schema.shape);
+}
+
+/**
+ * Result of a DTO-driven variable search.
+ *
+ * Holds the parsed variable values keyed by their declared name. Provides lenient, defensive
+ * access via {@link has} / {@link get}, and a strict {@link validate} that parses the values
+ * against the schema — returning a fully-typed object or throwing a `ZodError` when a required
+ * variable is missing or malformed.
+ */
+export class VariableMap<TSchema extends AnyVariableSchema> {
+  constructor(
+    private readonly _raw: Readonly<Record<string, unknown>>,
+    private readonly _schema: TSchema
+  ) {}
+
+  /** The parsed variable values, keyed by variable name. */
+  get raw(): Readonly<Record<string, unknown>> {
+    return this._raw;
+  }
+
+  /** Whether a variable with the given name is present in the result. */
+  has(variableName: string): boolean {
+    return Object.hasOwn(this._raw, variableName);
+  }
+
+  /** Lenient access. Returns the parsed value, or `undefined` when the variable is absent. */
+  get(variableName: string): unknown {
+    return this.has(variableName) ? this._raw[variableName] : undefined;
+  }
+
+  /**
+   * Strict access. Parses the collected values against the schema and returns the typed object.
+   * Required variables must be present and well-formed, otherwise a `ZodError` is thrown.
+   */
+  validate(): z.infer<TSchema> {
+    return this._schema.parse(this._raw);
+  }
+}
+
+function parseValue(variableName: string, value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch (cause) {
+    throw new VariableDeserializationError(variableName, { cause });
+  }
+}
+
+/**
+ * Incrementally collapses paged variable items into a parsed name-to-value map.
+ *
+ * Memory stays bounded by the DTO shape rather than the total number of paged items: only the
+ * first value seen per requested name is retained, alongside the set of scope keys observed for
+ * that name (used for collision detection). Items for undeclared variables are dropped, so large
+ * values for variables outside the DTO are never accumulated.
+ */
+export class VariableCollector {
+  private readonly _queryNames: Set<string>;
+  private readonly _chosenValues = new Map<string, string>();
+  private readonly _scopesSeen = new Map<string, Set<string>>();
+
+  constructor(queryNames: Iterable<string>) {
+    this._queryNames = new Set(queryNames);
+  }
+
+  /** Fold one page of results into the retained per-name state. */
+  ingest(items: Iterable<TypedVariableItem>): void {
+    for (const item of items) {
+      if (!this._queryNames.has(item.name)) {
+        continue;
+      }
+      let scopes = this._scopesSeen.get(item.name);
+      if (!scopes) {
+        scopes = new Set();
+        this._scopesSeen.set(item.name, scopes);
+      }
+      scopes.add(item.scopeKey);
+      if (!this._chosenValues.has(item.name)) {
+        this._chosenValues.set(item.name, item.value);
+      }
+    }
+  }
+
+  /**
+   * Parse retained values, raising on scope collisions or malformed JSON.
+   * @throws {VariableScopeCollisionError} when a name was observed at more than one scope.
+   * @throws {VariableDeserializationError} when a retained value is not valid JSON.
+   */
+  build(): Record<string, unknown> {
+    const raw: Record<string, unknown> = {};
+    for (const [name, value] of this._chosenValues) {
+      const scopes = this._scopesSeen.get(name);
+      if (scopes && scopes.size > 1) {
+        throw new VariableScopeCollisionError(name, [...scopes].sort());
+      }
+      raw[name] = parseValue(name, value);
+    }
+    return raw;
+  }
+}
+
+/**
+ * Page through variable search results until every declared variable is found or the result set
+ * is exhausted, then collapse them into a {@link VariableMap}.
+ *
+ * Paging terminates when: all declared names have been seen, the server reports no next cursor,
+ * a page comes back empty, or a cursor repeats (a defensive guard against a server that never
+ * advances). The `fetchPage` callback isolates the HTTP call so the paging and collapse logic is
+ * unit-testable in isolation.
+ */
+export async function collectTypedVariables<TSchema extends AnyVariableSchema>(params: {
+  schema: TSchema;
+  fetchPage: (after: string | undefined) => Promise<TypedVariablePage>;
+}): Promise<VariableMap<TSchema>> {
+  const names = variableNamesFromSchema(params.schema);
+  if (names.length === 0) {
+    return new VariableMap({}, params.schema);
+  }
+
+  const collector = new VariableCollector(names);
+  const remaining = new Set(names);
+  const seenCursors = new Set<string>();
+  let after: string | undefined;
+
+  while (true) {
+    const page = await params.fetchPage(after);
+    collector.ingest(page.items);
+    for (const item of page.items) {
+      remaining.delete(item.name);
+    }
+
+    if (remaining.size === 0) {
+      break;
+    }
+    if (page.endCursor === null || page.items.length === 0) {
+      break;
+    }
+    if (seenCursors.has(page.endCursor)) {
+      break;
+    }
+    seenCursors.add(page.endCursor);
+    after = page.endCursor;
+  }
+
+  return new VariableMap(collector.build(), params.schema);
+}

--- a/src/runtime/typedVariables.ts
+++ b/src/runtime/typedVariables.ts
@@ -273,6 +273,34 @@ export interface VariableSearchPageInput<TFilter> {
 }
 
 /**
+ * Cross-runtime equivalent of `AbortSignal.prototype.throwIfAborted()`.
+ *
+ * `throwIfAborted` is a relatively recent addition and is not implemented in every browser the SDK
+ * claims to support; calling it where absent throws a `TypeError` before any request is issued. We
+ * feature-detect it and otherwise replicate its contract: throw the signal's `reason` when present,
+ * or a synthesized `AbortError` when already aborted, so cancellation behaves consistently across
+ * Node and browsers.
+ */
+function throwIfAborted(signal: AbortSignal): void {
+  if (typeof signal.throwIfAborted === 'function') {
+    signal.throwIfAborted();
+    return;
+  }
+  if (signal.aborted) {
+    throw signal.reason ?? createAbortError();
+  }
+}
+
+function createAbortError(): Error {
+  if (typeof DOMException === 'function') {
+    return new DOMException('This operation was aborted', 'AbortError');
+  }
+  const error = new Error('This operation was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+/**
  * Build the `fetchPage` callback for {@link collectTypedVariables} that drives the variable search
  * API. For each page it: aborts early if the outer signal is already aborted, issues the request
  * with the declared-name filter and `truncateValues: false` (full values are required to bind the
@@ -293,7 +321,7 @@ export function createVariableSearchFetchPage<TFilter>(params: {
   const { filter, limit, signal, search } = params;
   return async (after) => {
     // Honour cancellation of the returned CancelablePromise between pages.
-    signal.throwIfAborted();
+    throwIfAborted(signal);
     const input: VariableSearchPageInput<TFilter> = {
       filter,
       // Cursors are opaque; only an explicit `undefined` means "no cursor". An empty-string

--- a/src/runtime/typedVariables.ts
+++ b/src/runtime/typedVariables.ts
@@ -195,9 +195,33 @@ export class VariableCollector {
   }
 }
 
+/** Eventual-consistency tolerance for a DTO-driven variable search. */
+export interface VariableConsistencyOptions {
+  /** How long to keep re-reading for the declared variables to become visible, in ms. `0` (the
+   * default) reads once and returns whatever is currently indexed. */
+  waitUpToMs: number;
+  /** How often to re-read while waiting, in ms. Defaults to 500ms (floored at 10ms). */
+  pollIntervalMs?: number;
+}
+
 /**
- * Page through variable search results until every declared variable is found or the result set
- * is exhausted, then collapse them into a {@link VariableMap}.
+ * Injectable time source for {@link collectTypedVariables}'s consistency loop. Defaults to real
+ * wall-clock time; tests supply a deterministic fake so polling behaviour is exercised without
+ * real delays.
+ */
+export interface CollectClock {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+}
+
+const realClock: CollectClock = {
+  now: () => Date.now(),
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+/**
+ * Page through one full pass of the variable search, folding every page into `collector` and
+ * returning the declared names still missing afterwards.
  *
  * Paging terminates when: the server reports no next cursor, a page comes back empty, or a cursor
  * repeats (a defensive guard against a server that never advances). The "all declared names seen"
@@ -205,29 +229,20 @@ export class VariableCollector {
  * single scope, where each name can appear at most once. When the query spans multiple scopes,
  * stopping early on "all found" could miss the same name reappearing at a second scope on a later
  * page, silently hiding a {@link VariableScopeCollisionError}; so paging continues to exhaustion.
- *
- * The `fetchPage` callback isolates the HTTP call so the paging and collapse logic is
- * unit-testable in isolation.
  */
-export async function collectTypedVariables<TSchema extends AnyVariableSchema>(params: {
-  schema: TSchema;
-  /** Whether the query is scoped to a single scope (collisions impossible, early-stop safe). */
+async function collectAllPages(params: {
+  names: readonly string[];
   singleScope: boolean;
+  collector: VariableCollector;
   fetchPage: (after: string | undefined) => Promise<TypedVariablePage>;
-}): Promise<VariableMap<TSchema>> {
-  const names = variableNamesFromSchema(params.schema);
-  if (names.length === 0) {
-    return new VariableMap({}, params.schema);
-  }
-
-  const collector = new VariableCollector(names);
-  const remaining = new Set(names);
+}): Promise<Set<string>> {
+  const remaining = new Set(params.names);
   const seenCursors = new Set<string>();
   let after: string | undefined;
 
   while (true) {
     const page = await params.fetchPage(after);
-    collector.ingest(page.items);
+    params.collector.ingest(page.items);
     for (const item of page.items) {
       remaining.delete(item.name);
     }
@@ -248,7 +263,66 @@ export async function collectTypedVariables<TSchema extends AnyVariableSchema>(p
     after = page.endCursor;
   }
 
-  return new VariableMap(collector.build(), params.schema);
+  return remaining;
+}
+
+/**
+ * Page through variable search results until every declared variable is found or the result set
+ * is exhausted, then collapse them into a {@link VariableMap}.
+ *
+ * Eventual-consistency waiting (when `consistency.waitUpToMs > 0`) is applied here, at the
+ * collection level — not on the underlying search calls. A freshly-written instance indexes its
+ * declared variables independently, so an early read can return only a subset (e.g. `orderId`
+ * before `amount`). Waiting on the first *search* alone is too weak: that search's success
+ * condition is "at least one matching variable", so it settles on a partial result. Instead we
+ * re-run the whole collection until every declared name is visible or the budget expires. On
+ * expiry we return the best snapshot gathered so far rather than throwing: a genuinely-absent
+ * variable is indistinguishable from a late one, and {@link VariableMap.validate} is the right
+ * place to surface a missing required variable. This also keeps pagination correct — a paging
+ * read that legitimately returns zero items never blocks, because the inner search never waits.
+ *
+ * The `fetchPage` callback isolates the HTTP call so the paging and collapse logic is
+ * unit-testable in isolation; `clock` isolates time so the consistency loop is too.
+ */
+export async function collectTypedVariables<TSchema extends AnyVariableSchema>(params: {
+  schema: TSchema;
+  /** Whether the query is scoped to a single scope (collisions impossible, early-stop safe). */
+  singleScope: boolean;
+  fetchPage: (after: string | undefined) => Promise<TypedVariablePage>;
+  /** Eventual-consistency tolerance. Omitted or `waitUpToMs: 0` reads exactly once. */
+  consistency?: VariableConsistencyOptions;
+  /** Injectable clock for deterministic tests; defaults to real time. */
+  clock?: CollectClock;
+}): Promise<VariableMap<TSchema>> {
+  const names = variableNamesFromSchema(params.schema);
+  if (names.length === 0) {
+    return new VariableMap({}, params.schema);
+  }
+
+  const clock = params.clock ?? realClock;
+  const waitUpToMs = params.consistency?.waitUpToMs ?? 0;
+  const pollIntervalMs = Math.max(10, params.consistency?.pollIntervalMs ?? 500);
+  const deadline = clock.now() + waitUpToMs;
+
+  while (true) {
+    // A fresh collector each pass: re-reads must reflect the latest snapshot, not accumulate
+    // stale per-name state across attempts.
+    const collector = new VariableCollector(names);
+    const remaining = await collectAllPages({
+      names,
+      singleScope: params.singleScope,
+      collector,
+      fetchPage: params.fetchPage,
+    });
+
+    // All declared variables are visible, or we are out of budget: return the best snapshot.
+    if (remaining.size === 0 || waitUpToMs === 0 || clock.now() >= deadline) {
+      return new VariableMap(collector.build(), params.schema);
+    }
+
+    // Cap the wait so we never sleep past the deadline.
+    await clock.sleep(Math.min(pollIntervalMs, deadline - clock.now()));
+  }
 }
 
 /**

--- a/src/runtime/typedVariables.ts
+++ b/src/runtime/typedVariables.ts
@@ -103,7 +103,7 @@ export class VariableMap<TSchema extends AnyVariableSchema> {
   }
 
   /** Whether a variable with the given name is present in the result. */
-  has<K extends keyof z.infer<TSchema> & string>(variableName: K): boolean;
+  has(variableName: keyof z.infer<TSchema> & string): boolean;
   has(variableName: string): boolean;
   has(variableName: string): boolean {
     return Object.hasOwn(this._raw, variableName);
@@ -112,12 +112,13 @@ export class VariableMap<TSchema extends AnyVariableSchema> {
   /**
    * Lenient access. Returns the parsed value, or `undefined` when the variable is absent.
    *
-   * For a declared schema key the return type is narrowed to that field's type (still unioned
-   * with `undefined`, since the variable may be absent at runtime); arbitrary string keys return
-   * `unknown`.
+   * A declared schema key is narrowed to that field's type unioned with `undefined` (the variable
+   * may be absent at runtime). Any other key resolves to `undefined`: the result only ever holds
+   * the declared variable names, so an undeclared key can never carry a value.
    */
-  get<K extends keyof z.infer<TSchema> & string>(variableName: K): z.infer<TSchema>[K] | undefined;
-  get(variableName: string): unknown;
+  get<K extends string>(
+    variableName: K
+  ): K extends keyof z.infer<TSchema> ? z.infer<TSchema>[K] | undefined : undefined;
   get(variableName: string): unknown {
     return this.has(variableName) ? this._raw[variableName] : undefined;
   }

--- a/src/runtime/typedVariables.ts
+++ b/src/runtime/typedVariables.ts
@@ -293,13 +293,18 @@ export function createVariableSearchFetchPage<TFilter>(params: {
     signal.throwIfAborted();
     const input: VariableSearchPageInput<TFilter> = {
       filter,
-      page: after ? { after, limit } : { limit },
+      // Cursors are opaque; only an explicit `undefined` means "no cursor". An empty-string
+      // cursor is a valid value and must be forwarded as `page.after`.
+      page: after !== undefined ? { after, limit } : { limit },
       truncateValues: false,
     };
     const pending = search(input);
     // Propagate outer cancellation to the in-flight paging request so it aborts too.
     const onAbort = () => pending.cancel();
     signal.addEventListener('abort', onAbort, { once: true });
+    // Guard the race where the signal aborted between throwIfAborted() and addEventListener():
+    // the abort event already fired, so cancel the in-flight request explicitly.
+    if (signal.aborted) onAbort();
     const result = await Promise.resolve(pending).finally(() =>
       signal.removeEventListener('abort', onAbort)
     );

--- a/src/runtime/typedVariables.ts
+++ b/src/runtime/typedVariables.ts
@@ -92,11 +92,21 @@ export class VariableMap<TSchema extends AnyVariableSchema> {
   }
 
   /** Whether a variable with the given name is present in the result. */
+  has<K extends keyof z.infer<TSchema> & string>(variableName: K): boolean;
+  has(variableName: string): boolean;
   has(variableName: string): boolean {
     return Object.hasOwn(this._raw, variableName);
   }
 
-  /** Lenient access. Returns the parsed value, or `undefined` when the variable is absent. */
+  /**
+   * Lenient access. Returns the parsed value, or `undefined` when the variable is absent.
+   *
+   * For a declared schema key the return type is narrowed to that field's type (still unioned
+   * with `undefined`, since the variable may be absent at runtime); arbitrary string keys return
+   * `unknown`.
+   */
+  get<K extends keyof z.infer<TSchema> & string>(variableName: K): z.infer<TSchema>[K] | undefined;
+  get(variableName: string): unknown;
   get(variableName: string): unknown {
     return this.has(variableName) ? this._raw[variableName] : undefined;
   }
@@ -175,13 +185,20 @@ export class VariableCollector {
  * Page through variable search results until every declared variable is found or the result set
  * is exhausted, then collapse them into a {@link VariableMap}.
  *
- * Paging terminates when: all declared names have been seen, the server reports no next cursor,
- * a page comes back empty, or a cursor repeats (a defensive guard against a server that never
- * advances). The `fetchPage` callback isolates the HTTP call so the paging and collapse logic is
+ * Paging terminates when: the server reports no next cursor, a page comes back empty, or a cursor
+ * repeats (a defensive guard against a server that never advances). The "all declared names seen"
+ * early-stop is only applied when `singleScope` is true — i.e. the query is already scoped to a
+ * single scope, where each name can appear at most once. When the query spans multiple scopes,
+ * stopping early on "all found" could miss the same name reappearing at a second scope on a later
+ * page, silently hiding a {@link VariableScopeCollisionError}; so paging continues to exhaustion.
+ *
+ * The `fetchPage` callback isolates the HTTP call so the paging and collapse logic is
  * unit-testable in isolation.
  */
 export async function collectTypedVariables<TSchema extends AnyVariableSchema>(params: {
   schema: TSchema;
+  /** Whether the query is scoped to a single scope (collisions impossible, early-stop safe). */
+  singleScope: boolean;
   fetchPage: (after: string | undefined) => Promise<TypedVariablePage>;
 }): Promise<VariableMap<TSchema>> {
   const names = variableNamesFromSchema(params.schema);
@@ -201,7 +218,10 @@ export async function collectTypedVariables<TSchema extends AnyVariableSchema>(p
       remaining.delete(item.name);
     }
 
-    if (remaining.size === 0) {
+    // Only safe to stop on "all found" when collisions are impossible (single scope). Otherwise
+    // a later page could reveal a second scope for an already-seen name — keep paging so build()
+    // can raise the collision rather than silently returning an ambiguous value.
+    if (params.singleScope && remaining.size === 0) {
       break;
     }
     if (page.endCursor === null || page.items.length === 0) {

--- a/src/runtime/typedVariables.ts
+++ b/src/runtime/typedVariables.ts
@@ -103,22 +103,24 @@ export class VariableMap<TSchema extends AnyVariableSchema> {
   }
 
   /** Whether a variable with the given name is present in the result. */
-  has(variableName: keyof z.infer<TSchema> & string): boolean;
+  has(variableName: keyof z.input<TSchema> & string): boolean;
   has(variableName: string): boolean;
   has(variableName: string): boolean {
     return Object.hasOwn(this._raw, variableName);
   }
 
   /**
-   * Lenient access. Returns the parsed value, or `undefined` when the variable is absent.
+   * Lenient access. Returns the JSON-parsed wire value, or `undefined` when the variable is absent.
    *
-   * A declared schema key is narrowed to that field's type unioned with `undefined` (the variable
-   * may be absent at runtime). Any other key resolves to `undefined`: the result only ever holds
-   * the declared variable names, so an undeclared key can never carry a value.
+   * The value is *not* run through the schema, so a declared key is narrowed to that field's schema
+   * *input* type (`z.input`) unioned with `undefined` — not the post-validation output type. This
+   * keeps the type honest for schemas with transforms or effects, where the parsed wire value can
+   * differ from `validate()`'s output. Any other key resolves to `undefined`: the result only ever
+   * holds the declared variable names, so an undeclared key can never carry a value.
    */
   get<K extends string>(
     variableName: K
-  ): K extends keyof z.infer<TSchema> ? z.infer<TSchema>[K] | undefined : undefined;
+  ): K extends keyof z.input<TSchema> ? z.input<TSchema>[K] | undefined : undefined;
   get(variableName: string): unknown {
     return this.has(variableName) ? this._raw[variableName] : undefined;
   }

--- a/src/template/CamundaClient.template.ts
+++ b/src/template/CamundaClient.template.ts
@@ -21,6 +21,12 @@ import {
 } from '../runtime/telemetry';
 import { ValidationManager } from '../runtime/validationManager';
 import type { Client } from '../gen/client/types.gen';
+import type {
+  ProcessInstanceKey,
+  ScopeKey,
+  TenantId,
+  VariableSearchResult,
+} from '../gen/types.gen';
 import {
   executeWithHttpRetry,
   defaultHttpClassifier,
@@ -719,9 +725,9 @@ export class CamundaClient {
   searchVariablesAsDto<TSchema extends AnyVariableSchema>(
     schema: TSchema,
     options: {
-      processInstanceKey: string;
-      scopeKey?: string;
-      tenantId?: string;
+      processInstanceKey: ProcessInstanceKey;
+      scopeKey?: ScopeKey;
+      tenantId?: TenantId;
       pageSize?: number;
     }
   ): CancelablePromise<VariableMap<TSchema>> {
@@ -740,6 +746,10 @@ export class CamundaClient {
 
       return collectTypedVariables({
         schema,
+        // A single scopeKey restricts results to one scope, so each declared name appears at most
+        // once and paging can stop as soon as all are found. Otherwise we page to exhaustion so a
+        // same-name/different-scope collision on a later page surfaces as a VariableScopeCollisionError.
+        singleScope: Boolean(options.scopeKey),
         fetchPage: async (after) => {
           const input = {
             filter,
@@ -749,7 +759,7 @@ export class CamundaClient {
           };
           // @ts-ignore - searchVariables method & input type injected by generator
           const result = await this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
-          const items = (result?.items ?? []).map((item: any) => ({
+          const items = (result?.items ?? []).map((item: VariableSearchResult) => ({
             name: item.name,
             value: item.value,
             scopeKey: String(item.scopeKey),

--- a/src/template/CamundaClient.template.ts
+++ b/src/template/CamundaClient.template.ts
@@ -29,6 +29,12 @@ import {
 } from '../runtime/retry';
 import { normalizeError } from '../runtime/errors';
 import { BackpressureManager } from '../runtime/backpressure';
+import {
+  type AnyVariableSchema,
+  collectTypedVariables,
+  type VariableMap,
+  variableNamesFromSchema,
+} from '../runtime/typedVariables';
 import { JobWorker, type JobWorkerConfig } from '../runtime/jobWorker';
 import { ThreadedJobWorker, type ThreadedJobWorkerConfig } from '../runtime/threadedJobWorker';
 import { ThreadPool } from '../runtime/threadPool';
@@ -679,6 +685,78 @@ export class CamundaClient {
       } as any;
       // @ts-ignore - createDeployment method injected by generator
       return this.createDeployment(payload);
+    });
+  }
+
+  /**
+   * Search for process variables and bind them to a Zod schema (the DTO).
+   *
+   * The schema's keys are the exact variable names to fetch; its shape drives validation. Only
+   * those declared variables are queried (via a `name $in [...]` filter), so memory stays bound
+   * by the DTO shape rather than the total number of variables on the instance. Results are
+   * paged internally until every declared variable is found or the result set is exhausted.
+   *
+   * Returns a {@link VariableMap} offering lenient access (`has` / `get`) and a strict
+   * `validate()` that parses the collected values against the schema — returning a fully-typed
+   * object or throwing a `ZodError` when a required variable is missing or malformed.
+   *
+   * @param schema A Zod object schema declaring the variables to fetch.
+   * @param options Query scope. `processInstanceKey` is required; `scopeKey` narrows to a single
+   *   element-instance scope, `tenantId` filters by tenant, and `pageSize` tunes the page limit.
+   * @throws {VariableScopeCollisionError} when a declared variable is found at more than one
+   *   scope and no `scopeKey` was provided to disambiguate.
+   * @throws {VariableDeserializationError} when a variable's value is not valid JSON.
+   *
+   * @example
+   * ```ts
+   * import { z } from 'zod';
+   * const OrderVariables = z.object({ orderId: z.string(), amount: z.number().optional() });
+   * const map = await client.searchVariablesAsDto(OrderVariables, { processInstanceKey });
+   * if (map.has('amount')) console.log(map.get('amount'));
+   * const order = map.validate(); // { orderId: string; amount?: number }
+   * ```
+   */
+  searchVariablesAsDto<TSchema extends AnyVariableSchema>(
+    schema: TSchema,
+    options: {
+      processInstanceKey: string;
+      scopeKey?: string;
+      tenantId?: string;
+      pageSize?: number;
+    }
+  ): CancelablePromise<VariableMap<TSchema>> {
+    return toCancelable(async (_signal) => {
+      if (!options?.processInstanceKey) {
+        throw new Error('searchVariablesAsDto requires options.processInstanceKey');
+      }
+      const names = variableNamesFromSchema(schema);
+      const limit = options.pageSize && options.pageSize > 0 ? options.pageSize : 100;
+      const filter: Record<string, unknown> = {
+        name: { $in: names },
+        processInstanceKey: options.processInstanceKey,
+      };
+      if (options.scopeKey) filter.scopeKey = options.scopeKey;
+      if (options.tenantId) filter.tenantId = options.tenantId;
+
+      return collectTypedVariables({
+        schema,
+        fetchPage: async (after) => {
+          const input = {
+            filter,
+            page: after ? { after, limit } : { limit },
+            // Full values are required to bind the DTO; never truncate.
+            truncateValues: false,
+          };
+          // @ts-ignore - searchVariables method & input type injected by generator
+          const result = await this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
+          const items = (result?.items ?? []).map((item: any) => ({
+            name: item.name,
+            value: item.value,
+            scopeKey: String(item.scopeKey),
+          }));
+          return { items, endCursor: result?.page?.endCursor ?? null };
+        },
+      });
     });
   }
 }

--- a/src/template/CamundaClient.template.ts
+++ b/src/template/CamundaClient.template.ts
@@ -745,28 +745,23 @@ export class CamundaClient {
       if (options.scopeKey) filter.scopeKey = options.scopeKey;
       if (options.tenantId) filter.tenantId = options.tenantId;
 
-      // Default to no eventual-consistency wait, but let callers opt into polling for a stable
-      // snapshot when querying a freshly-updated instance.
-      const consistency = options.consistency ?? { waitUpToMs: 0 };
-
       return collectTypedVariables({
         schema,
         // A single scopeKey restricts results to one scope, so each declared name appears at most
         // once and paging can stop as soon as all are found. Otherwise we page to exhaustion so a
         // same-name/different-scope collision on a later page surfaces as a VariableScopeCollisionError.
         singleScope: Boolean(options.scopeKey),
+        // Eventual-consistency waiting happens at the collection level: re-read until every declared
+        // variable is visible or the budget expires. The per-page search never waits — a paging read
+        // that legitimately returns 0 items must not block, and waiting on the first search alone
+        // settles on a partial result (its success condition is merely "any matching variable").
+        consistency: options.consistency,
         fetchPage: createVariableSearchFetchPage({
           filter,
           limit,
           signal,
           // @ts-ignore - searchVariables method & input type injected by generator
-          search: (input) => {
-            // Only apply eventual consistency polling to the first search (no cursor).
-            // Pagination searches should return immediately with whatever results are available,
-            // including empty results, which are valid when there are no more pages.
-            const useConsistency = input.page.after === undefined ? consistency : { waitUpToMs: 0 };
-            return this.searchVariables(input, { consistency: useConsistency });
-          },
+          search: (input) => this.searchVariables(input, { consistency: { waitUpToMs: 0 } }),
         }),
       });
     });

--- a/src/template/CamundaClient.template.ts
+++ b/src/template/CamundaClient.template.ts
@@ -21,13 +21,7 @@ import {
 } from '../runtime/telemetry';
 import { ValidationManager } from '../runtime/validationManager';
 import type { Client } from '../gen/client/types.gen';
-import type {
-  ProcessInstanceKey,
-  ScopeKey,
-  TenantId,
-  VariableFilter,
-  VariableSearchResult,
-} from '../gen/types.gen';
+import type { ProcessInstanceKey, ScopeKey, TenantId, VariableFilter } from '../gen/types.gen';
 import {
   executeWithHttpRetry,
   defaultHttpClassifier,
@@ -39,6 +33,7 @@ import { BackpressureManager } from '../runtime/backpressure';
 import {
   type AnyVariableSchema,
   collectTypedVariables,
+  createVariableSearchFetchPage,
   type VariableMap,
   variableNamesFromSchema,
 } from '../runtime/typedVariables';
@@ -751,28 +746,13 @@ export class CamundaClient {
         // once and paging can stop as soon as all are found. Otherwise we page to exhaustion so a
         // same-name/different-scope collision on a later page surfaces as a VariableScopeCollisionError.
         singleScope: Boolean(options.scopeKey),
-        fetchPage: async (after) => {
-          // Honour cancellation of the returned CancelablePromise between pages.
-          signal.throwIfAborted();
-          const input = {
-            filter,
-            page: after ? { after, limit } : { limit },
-            // Full values are required to bind the DTO; never truncate.
-            truncateValues: false,
-          };
+        fetchPage: createVariableSearchFetchPage({
+          filter,
+          limit,
+          signal,
           // @ts-ignore - searchVariables method & input type injected by generator
-          const pending = this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
-          // Propagate outer cancellation to the in-flight paging request so it aborts too.
-          const onAbort = () => pending.cancel();
-          signal.addEventListener('abort', onAbort, { once: true });
-          const result = await pending.finally(() => signal.removeEventListener('abort', onAbort));
-          const items = (result?.items ?? []).map((item: VariableSearchResult) => ({
-            name: item.name,
-            value: item.value,
-            scopeKey: String(item.scopeKey),
-          }));
-          return { items, endCursor: result?.page?.endCursor ?? null };
-        },
+          search: (input) => this.searchVariables(input, { consistency: { waitUpToMs: 0 } }),
+        }),
       });
     });
   }

--- a/src/template/CamundaClient.template.ts
+++ b/src/template/CamundaClient.template.ts
@@ -760,7 +760,13 @@ export class CamundaClient {
           limit,
           signal,
           // @ts-ignore - searchVariables method & input type injected by generator
-          search: (input) => this.searchVariables(input, { consistency }),
+          search: (input) => {
+            // Only apply eventual consistency polling to the first search (no cursor).
+            // Pagination searches should return immediately with whatever results are available,
+            // including empty results, which are valid when there are no more pages.
+            const useConsistency = input.page.after === undefined ? consistency : { waitUpToMs: 0 };
+            return this.searchVariables(input, { consistency: useConsistency });
+          },
         }),
       });
     });

--- a/src/template/CamundaClient.template.ts
+++ b/src/template/CamundaClient.template.ts
@@ -705,6 +705,10 @@ export class CamundaClient {
    * @param schema A Zod object schema declaring the variables to fetch.
    * @param options Query scope. `processInstanceKey` is required; `scopeKey` narrows to a single
    *   element-instance scope, `tenantId` filters by tenant, and `pageSize` tunes the page limit.
+   *   `consistency` controls eventual-consistency tolerance for the underlying `searchVariables`
+   *   calls: it defaults to `{ waitUpToMs: 0 }` (no waiting), but a non-zero `waitUpToMs` makes the
+   *   paging calls poll until the data is consistent, avoiding intermittent missing variables /
+   *   `ZodError` on a freshly-updated instance.
    * @throws {VariableScopeCollisionError} when a declared variable is found at more than one
    *   scope and no `scopeKey` was provided to disambiguate.
    * @throws {VariableDeserializationError} when a variable's value is not valid JSON.
@@ -725,6 +729,7 @@ export class CamundaClient {
       scopeKey?: ScopeKey;
       tenantId?: TenantId;
       pageSize?: number;
+      consistency?: { waitUpToMs: number; pollIntervalMs?: number };
     }
   ): CancelablePromise<VariableMap<TSchema>> {
     return toCancelable(async (signal) => {
@@ -740,6 +745,10 @@ export class CamundaClient {
       if (options.scopeKey) filter.scopeKey = options.scopeKey;
       if (options.tenantId) filter.tenantId = options.tenantId;
 
+      // Default to no eventual-consistency wait, but let callers opt into polling for a stable
+      // snapshot when querying a freshly-updated instance.
+      const consistency = options.consistency ?? { waitUpToMs: 0 };
+
       return collectTypedVariables({
         schema,
         // A single scopeKey restricts results to one scope, so each declared name appears at most
@@ -751,7 +760,7 @@ export class CamundaClient {
           limit,
           signal,
           // @ts-ignore - searchVariables method & input type injected by generator
-          search: (input) => this.searchVariables(input, { consistency: { waitUpToMs: 0 } }),
+          search: (input) => this.searchVariables(input, { consistency }),
         }),
       });
     });

--- a/src/template/CamundaClient.template.ts
+++ b/src/template/CamundaClient.template.ts
@@ -25,6 +25,7 @@ import type {
   ProcessInstanceKey,
   ScopeKey,
   TenantId,
+  VariableFilter,
   VariableSearchResult,
 } from '../gen/types.gen';
 import {
@@ -731,13 +732,13 @@ export class CamundaClient {
       pageSize?: number;
     }
   ): CancelablePromise<VariableMap<TSchema>> {
-    return toCancelable(async (_signal) => {
+    return toCancelable(async (signal) => {
       if (!options?.processInstanceKey) {
         throw new Error('searchVariablesAsDto requires options.processInstanceKey');
       }
       const names = variableNamesFromSchema(schema);
       const limit = options.pageSize && options.pageSize > 0 ? options.pageSize : 100;
-      const filter: Record<string, unknown> = {
+      const filter: VariableFilter = {
         name: { $in: names },
         processInstanceKey: options.processInstanceKey,
       };
@@ -751,6 +752,8 @@ export class CamundaClient {
         // same-name/different-scope collision on a later page surfaces as a VariableScopeCollisionError.
         singleScope: Boolean(options.scopeKey),
         fetchPage: async (after) => {
+          // Honour cancellation of the returned CancelablePromise between pages.
+          signal.throwIfAborted();
           const input = {
             filter,
             page: after ? { after, limit } : { limit },
@@ -758,7 +761,11 @@ export class CamundaClient {
             truncateValues: false,
           };
           // @ts-ignore - searchVariables method & input type injected by generator
-          const result = await this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
+          const pending = this.searchVariables(input, { consistency: { waitUpToMs: 0 } });
+          // Propagate outer cancellation to the in-flight paging request so it aborts too.
+          const onAbort = () => pending.cancel();
+          signal.addEventListener('abort', onAbort, { once: true });
+          const result = await pending.finally(() => signal.removeEventListener('abort', onAbort));
           const items = (result?.items ?? []).map((item: VariableSearchResult) => ({
             name: item.name,
             value: item.value,

--- a/tests-integration/searchVariablesAsDto.test.ts
+++ b/tests-integration/searchVariablesAsDto.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { createCamundaClient } from '../src';
+
+describe('searchVariablesAsDto', () => {
+  it('finds process instance variables bound to a Dto', { timeout: 20_000 }, async () => {
+    const camunda = createCamundaClient();
+
+    const res = await camunda.deployResourcesFromFiles([
+      './tests-integration/fixtures/test-process.bpmn',
+    ]);
+
+    // The process waits at a service task, so its variables persist on the
+    // running instance for the duration of the search.
+    const orderId = `order-${Date.now()}`;
+    const process = await camunda.createProcessInstance({
+      processDefinitionKey: res.processes[0].processDefinitionKey,
+      variables: {
+        orderId,
+        amount: 42,
+        // An extra variable that is not declared on the Dto and must be ignored.
+        internalSecret: 'do-not-leak',
+      },
+    });
+
+    try {
+      // The Zod schema is the Dto: its keys are the exact variable names to
+      // fetch, and its shape drives validation.
+      const OrderVariables = z.object({
+        orderId: z.string(),
+        amount: z.number().optional(),
+      });
+
+      const map = await camunda.searchVariablesAsDto(OrderVariables, {
+        processInstanceKey: process.processInstanceKey,
+        // Variables are eventually consistent on a freshly-created instance, so
+        // poll until the declared variables are visible.
+        consistency: { waitUpToMs: 10_000 },
+      });
+
+      // Lenient access.
+      expect(map.has('orderId')).toBe(true);
+      expect(map.has('amount')).toBe(true);
+      expect(map.get('orderId')).toBe(orderId);
+      expect(map.get('amount')).toBe(42);
+
+      // Only the declared variables are queried — the extra one is never fetched.
+      expect(map.has('internalSecret')).toBe(false);
+      expect(Object.keys(map.raw).sort()).toEqual(['amount', 'orderId']);
+
+      // Strict access: returns a fully-typed, validated Dto.
+      const order = map.validate();
+      expect(order).toEqual({ orderId, amount: 42 });
+    } finally {
+      await camunda.cancelProcessInstance({
+        processInstanceKey: process.processInstanceKey,
+      });
+    }
+  });
+
+  it('throws on validate when a required Dto field is missing at runtime', {
+    timeout: 20_000,
+  }, async () => {
+    const camunda = createCamundaClient();
+
+    const res = await camunda.deployResourcesFromFiles([
+      './tests-integration/fixtures/test-process.bpmn',
+    ]);
+
+    const orderId = `order-${Date.now()}`;
+    const process = await camunda.createProcessInstance({
+      processDefinitionKey: res.processes[0].processDefinitionKey,
+      variables: { orderId },
+    });
+
+    try {
+      // The Dto declares a required `customerId` variable that the instance
+      // never set, so it is absent at runtime.
+      const OrderVariables = z.object({
+        orderId: z.string(),
+        customerId: z.string(),
+      });
+
+      const map = await camunda.searchVariablesAsDto(OrderVariables, {
+        processInstanceKey: process.processInstanceKey,
+        consistency: { waitUpToMs: 10_000 },
+      });
+
+      // The declared-but-absent variable is simply missing — lenient access
+      // never throws.
+      expect(map.has('orderId')).toBe(true);
+      expect(map.has('customerId')).toBe(false);
+
+      // Strict validation fails because a required variable is missing.
+      expect(() => map.validate()).toThrowError(z.ZodError);
+    } finally {
+      await camunda.cancelProcessInstance({
+        processInstanceKey: process.processInstanceKey,
+      });
+    }
+  });
+});

--- a/tests/typed-variables.test.ts
+++ b/tests/typed-variables.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ZodError, z } from 'zod';
 import {
   type CancelableRequest,
+  type CollectClock,
   collectTypedVariables,
   createVariableSearchFetchPage,
   type TypedVariableItem,
@@ -254,6 +255,77 @@ describe('collectTypedVariables paging', () => {
     });
     expect(calls).toBe(0);
     expect(map.raw).toEqual({});
+  });
+});
+
+describe('collectTypedVariables eventual consistency', () => {
+  // A deterministic clock: advances by exactly the requested sleep, so the loop is driven by the
+  // sequence of fetchPage results rather than wall-clock time.
+  function fakeClock(): CollectClock {
+    let t = 0;
+    return {
+      now: () => t,
+      sleep: async (ms) => {
+        t += ms;
+      },
+    };
+  }
+
+  it('re-reads until every declared variable becomes visible (not just the first one)', async () => {
+    // Guards the defect class: declared variables index independently, so an early read can return
+    // a strict subset. A first-read-only wait settles on { orderId } and never sees `amount`.
+    const snapshots: TypedVariablePage[] = [
+      page([item('orderId', 'A-1')]), // amount not indexed yet
+      page([item('orderId', 'A-1')]), // still lagging
+      page([item('orderId', 'A-1'), item('amount', 42)]), // both visible now
+    ];
+    let calls = 0;
+    const map = await collectTypedVariables({
+      schema: OrderSchema,
+      singleScope: true,
+      consistency: { waitUpToMs: 10_000, pollIntervalMs: 100 },
+      clock: fakeClock(),
+      fetchPage: async () => snapshots[Math.min(calls++, snapshots.length - 1)],
+    });
+    expect(calls).toBe(3);
+    expect(map.has('orderId')).toBe(true);
+    expect(map.has('amount')).toBe(true);
+    expect(map.validate()).toEqual({ orderId: 'A-1', amount: 42 });
+  });
+
+  it('returns the partial snapshot when the budget expires (never hangs on an absent variable)', async () => {
+    // A genuinely-absent declared variable is indistinguishable from a late one: we must stop at
+    // the budget and return what we have, letting validate() surface the omission — not time out.
+    let calls = 0;
+    const map = await collectTypedVariables({
+      schema: OrderSchema,
+      singleScope: true,
+      consistency: { waitUpToMs: 250, pollIntervalMs: 100 },
+      clock: fakeClock(),
+      fetchPage: async () => {
+        calls += 1;
+        return page([item('orderId', 'A-1')]); // amount never appears
+      },
+    });
+    // First read at t=0, then sleeps of 100, 100, 50 -> next read at t=250 hits the deadline.
+    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(map.has('orderId')).toBe(true);
+    expect(map.has('amount')).toBe(false);
+  });
+
+  it('reads exactly once when no consistency wait is requested', async () => {
+    let calls = 0;
+    const map = await collectTypedVariables({
+      schema: OrderSchema,
+      singleScope: true,
+      clock: fakeClock(),
+      fetchPage: async () => {
+        calls += 1;
+        return page([item('orderId', 'A-1')]);
+      },
+    });
+    expect(calls).toBe(1);
+    expect(map.has('amount')).toBe(false);
   });
 });
 

--- a/tests/typed-variables.test.ts
+++ b/tests/typed-variables.test.ts
@@ -59,6 +59,16 @@ describe('VariableMap lenient access', () => {
     expect(map.get('missing')).toBeUndefined();
   });
 
+  it('types get() per key: schema keys narrow, non-schema keys are undefined', () => {
+    // Compile-time assertions (no runtime effect): a declared key narrows to its field type
+    // unioned with undefined; an undeclared key resolves to undefined since the map only ever
+    // holds declared variable names.
+    const orderId: string | undefined = map.get('orderId');
+    const amount: number | undefined = map.get('amount');
+    const missing: undefined = map.get('missing');
+    expect([orderId, amount, missing]).toBeDefined();
+  });
+
   it('exposes the raw record', () => {
     expect(map.raw).toEqual({ orderId: 'A-1', amount: 9.99 });
   });

--- a/tests/typed-variables.test.ts
+++ b/tests/typed-variables.test.ts
@@ -115,7 +115,7 @@ describe('VariableCollector', () => {
 });
 
 describe('collectTypedVariables paging', () => {
-  it('pages until every declared variable is found, then stops early', async () => {
+  it('pages until every declared variable is found, then stops early when scoped to one scope', async () => {
     const pages: TypedVariablePage[] = [
       page([item('orderId', 'A-1')], 'cursor-1'),
       page([item('amount', 9.99)], 'cursor-2'),
@@ -124,6 +124,8 @@ describe('collectTypedVariables paging', () => {
     let calls = 0;
     const map = await collectTypedVariables({
       schema: OrderSchema,
+      // Scoped to a single scope -> each name appears at most once -> early-stop is safe.
+      singleScope: true,
       fetchPage: async () => {
         const next = pages[calls];
         calls += 1;
@@ -135,10 +137,34 @@ describe('collectTypedVariables paging', () => {
     expect(map.validate()).toEqual({ orderId: 'A-1', amount: 9.99 });
   });
 
+  it('does not stop early when unscoped, surfacing a collision that only appears on a later page', async () => {
+    const pages: TypedVariablePage[] = [
+      // Page 1 already contains every declared name -> the old early-stop would terminate here.
+      page([item('orderId', 'A-1', 'scope-a'), item('amount', 9.99, 'scope-a')], 'cursor-1'),
+      // Page 2 reveals the same name at a second scope -> a collision the early-stop would miss.
+      page([item('orderId', 'A-2', 'scope-b')], null),
+    ];
+    let calls = 0;
+    await expect(
+      collectTypedVariables({
+        schema: OrderSchema,
+        singleScope: false,
+        fetchPage: async () => {
+          const next = pages[calls];
+          calls += 1;
+          return next;
+        },
+      })
+    ).rejects.toBeInstanceOf(VariableScopeCollisionError);
+    // Proves paging continued past page 1 despite all names being found on it.
+    expect(calls).toBe(2);
+  });
+
   it('stops when the server reports no next cursor', async () => {
     let calls = 0;
     const map = await collectTypedVariables({
       schema: OrderSchema,
+      singleScope: false,
       fetchPage: async () => {
         calls += 1;
         return page([item('orderId', 'A-1')], null);
@@ -153,6 +179,7 @@ describe('collectTypedVariables paging', () => {
     let calls = 0;
     const map = await collectTypedVariables({
       schema: OrderSchema,
+      singleScope: false,
       fetchPage: async () => {
         calls += 1;
         return page([], 'cursor-loops');
@@ -166,6 +193,7 @@ describe('collectTypedVariables paging', () => {
     let calls = 0;
     const map = await collectTypedVariables({
       schema: OrderSchema,
+      singleScope: false,
       fetchPage: async () => {
         calls += 1;
         return page([item('orderId', 'A-1')], 'stuck');
@@ -180,6 +208,7 @@ describe('collectTypedVariables paging', () => {
     let calls = 0;
     const map = await collectTypedVariables({
       schema: z.object({}),
+      singleScope: false,
       fetchPage: async () => {
         calls += 1;
         return page([]);

--- a/tests/typed-variables.test.ts
+++ b/tests/typed-variables.test.ts
@@ -69,6 +69,22 @@ describe('VariableMap lenient access', () => {
     expect([orderId, amount, missing]).toBeDefined();
   });
 
+  it('types get() against the schema INPUT, not the transformed output', () => {
+    // get() returns the JSON-parsed wire value without running the schema, so for a schema with a
+    // transform the lenient type must follow `z.input` (pre-transform), while validate() follows
+    // `z.infer` (post-transform). Guards the whole class of transform/effect schemas, not just one.
+    const TransformSchema = z.object({
+      count: z.string().transform((s) => Number.parseInt(s, 10)),
+    });
+    const transformed = new VariableMap({ count: '42' }, TransformSchema);
+    // Compile-time: get() yields the input type (string | undefined), not number.
+    const count: string | undefined = transformed.get('count');
+    // Compile-time: validate() yields the output type (number).
+    const validated: { count: number } = transformed.validate();
+    expect(count).toBe('42');
+    expect(validated.count).toBe(42);
+  });
+
   it('exposes the raw record', () => {
     expect(map.raw).toEqual({ orderId: 'A-1', amount: 9.99 });
   });

--- a/tests/typed-variables.test.ts
+++ b/tests/typed-variables.test.ts
@@ -93,7 +93,7 @@ describe('VariableCollector', () => {
     collector.ingest([item('orderId', 'A-1', 'scope-b'), item('orderId', 'A-2', 'scope-a')]);
     try {
       collector.build();
-      expect.unreachable('expected a scope collision');
+      throw new Error('expected a scope collision');
     } catch (error) {
       expect(error).toBeInstanceOf(VariableScopeCollisionError);
       expect((error as VariableScopeCollisionError).variableName).toBe('orderId');
@@ -106,7 +106,7 @@ describe('VariableCollector', () => {
     collector.ingest([{ name: 'orderId', value: 'not json', scopeKey: 'scope-1' }]);
     try {
       collector.build();
-      expect.unreachable('expected a deserialization error');
+      throw new Error('expected a deserialization error');
     } catch (error) {
       expect(error).toBeInstanceOf(VariableDeserializationError);
       expect((error as VariableDeserializationError).variableName).toBe('orderId');

--- a/tests/typed-variables.test.ts
+++ b/tests/typed-variables.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import { ZodError, z } from 'zod';
+import {
+  collectTypedVariables,
+  type TypedVariableItem,
+  type TypedVariablePage,
+  VariableCollector,
+  VariableDeserializationError,
+  VariableMap,
+  VariableScopeCollisionError,
+  variableNamesFromSchema,
+} from '../src/runtime/typedVariables';
+
+const OrderSchema = z.object({
+  orderId: z.string(),
+  amount: z.number().optional(),
+});
+
+function item(name: string, value: unknown, scopeKey = 'scope-1'): TypedVariableItem {
+  return { name, value: JSON.stringify(value), scopeKey };
+}
+
+function page(items: TypedVariableItem[], endCursor: string | null = null): TypedVariablePage {
+  return { items, endCursor };
+}
+
+describe('variableNamesFromSchema', () => {
+  it('returns all declared keys including optional ones', () => {
+    expect(variableNamesFromSchema(OrderSchema)).toEqual(['orderId', 'amount']);
+  });
+
+  it('returns an empty list for an empty schema', () => {
+    expect(variableNamesFromSchema(z.object({}))).toEqual([]);
+  });
+});
+
+describe('VariableMap lenient access', () => {
+  const map = new VariableMap({ orderId: 'A-1', amount: 9.99 }, OrderSchema);
+
+  it('reports presence via has()', () => {
+    expect(map.has('orderId')).toBe(true);
+    expect(map.has('missing')).toBe(false);
+  });
+
+  it('returns parsed values via get(), undefined when absent', () => {
+    expect(map.get('amount')).toBe(9.99);
+    expect(map.get('missing')).toBeUndefined();
+  });
+
+  it('exposes the raw record', () => {
+    expect(map.raw).toEqual({ orderId: 'A-1', amount: 9.99 });
+  });
+});
+
+describe('VariableMap.validate', () => {
+  it('returns the fully-typed object when required variables are present', () => {
+    const map = new VariableMap({ orderId: 'A-1', amount: 9.99 }, OrderSchema);
+    expect(map.validate()).toEqual({ orderId: 'A-1', amount: 9.99 });
+  });
+
+  it('succeeds when only optional variables are absent', () => {
+    const map = new VariableMap({ orderId: 'A-1' }, OrderSchema);
+    expect(map.validate()).toEqual({ orderId: 'A-1' });
+  });
+
+  it('throws ZodError when a required variable is missing', () => {
+    const map = new VariableMap({ amount: 9.99 }, OrderSchema);
+    expect(() => map.validate()).toThrow(ZodError);
+  });
+
+  it('throws ZodError when a present value has the wrong type', () => {
+    const map = new VariableMap({ orderId: 123 }, OrderSchema);
+    expect(() => map.validate()).toThrow(ZodError);
+  });
+});
+
+describe('VariableCollector', () => {
+  it('keeps the first value seen per name across pages (first wins)', () => {
+    const collector = new VariableCollector(['orderId']);
+    collector.ingest([item('orderId', 'first')]);
+    collector.ingest([item('orderId', 'second')]);
+    expect(collector.build()).toEqual({ orderId: 'first' });
+  });
+
+  it('drops items for undeclared variables to stay memory-bounded', () => {
+    const collector = new VariableCollector(['orderId']);
+    collector.ingest([item('orderId', 'A-1'), item('unrelated', 'huge-blob')]);
+    expect(collector.build()).toEqual({ orderId: 'A-1' });
+  });
+
+  it('throws VariableScopeCollisionError when a name appears at multiple scopes', () => {
+    const collector = new VariableCollector(['orderId']);
+    collector.ingest([item('orderId', 'A-1', 'scope-b'), item('orderId', 'A-2', 'scope-a')]);
+    try {
+      collector.build();
+      expect.unreachable('expected a scope collision');
+    } catch (error) {
+      expect(error).toBeInstanceOf(VariableScopeCollisionError);
+      expect((error as VariableScopeCollisionError).variableName).toBe('orderId');
+      expect((error as VariableScopeCollisionError).scopeKeys).toEqual(['scope-a', 'scope-b']);
+    }
+  });
+
+  it('throws VariableDeserializationError when a value is not valid JSON', () => {
+    const collector = new VariableCollector(['orderId']);
+    collector.ingest([{ name: 'orderId', value: 'not json', scopeKey: 'scope-1' }]);
+    try {
+      collector.build();
+      expect.unreachable('expected a deserialization error');
+    } catch (error) {
+      expect(error).toBeInstanceOf(VariableDeserializationError);
+      expect((error as VariableDeserializationError).variableName).toBe('orderId');
+    }
+  });
+});
+
+describe('collectTypedVariables paging', () => {
+  it('pages until every declared variable is found, then stops early', async () => {
+    const pages: TypedVariablePage[] = [
+      page([item('orderId', 'A-1')], 'cursor-1'),
+      page([item('amount', 9.99)], 'cursor-2'),
+      page([item('shouldNotBeFetched', 'x')], 'cursor-3'),
+    ];
+    let calls = 0;
+    const map = await collectTypedVariables({
+      schema: OrderSchema,
+      fetchPage: async () => {
+        const next = pages[calls];
+        calls += 1;
+        return next;
+      },
+    });
+    // Stops after page 2 because both names were found.
+    expect(calls).toBe(2);
+    expect(map.validate()).toEqual({ orderId: 'A-1', amount: 9.99 });
+  });
+
+  it('stops when the server reports no next cursor', async () => {
+    let calls = 0;
+    const map = await collectTypedVariables({
+      schema: OrderSchema,
+      fetchPage: async () => {
+        calls += 1;
+        return page([item('orderId', 'A-1')], null);
+      },
+    });
+    expect(calls).toBe(1);
+    expect(map.has('orderId')).toBe(true);
+    expect(map.has('amount')).toBe(false);
+  });
+
+  it('stops when a page comes back empty', async () => {
+    let calls = 0;
+    const map = await collectTypedVariables({
+      schema: OrderSchema,
+      fetchPage: async () => {
+        calls += 1;
+        return page([], 'cursor-loops');
+      },
+    });
+    expect(calls).toBe(1);
+    expect(map.raw).toEqual({});
+  });
+
+  it('stops when a cursor repeats (defensive guard)', async () => {
+    let calls = 0;
+    const map = await collectTypedVariables({
+      schema: OrderSchema,
+      fetchPage: async () => {
+        calls += 1;
+        return page([item('orderId', 'A-1')], 'stuck');
+      },
+    });
+    // First page returns 'stuck'; second page returns 'stuck' again -> terminate.
+    expect(calls).toBe(2);
+    expect(map.has('orderId')).toBe(true);
+  });
+
+  it('returns an empty map without fetching for an empty schema', async () => {
+    let calls = 0;
+    const map = await collectTypedVariables({
+      schema: z.object({}),
+      fetchPage: async () => {
+        calls += 1;
+        return page([]);
+      },
+    });
+    expect(calls).toBe(0);
+    expect(map.raw).toEqual({});
+  });
+});

--- a/tests/typed-variables.test.ts
+++ b/tests/typed-variables.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { ZodError, z } from 'zod';
 import {
+  type CancelableRequest,
   collectTypedVariables,
+  createVariableSearchFetchPage,
   type TypedVariableItem,
   type TypedVariablePage,
+  TypedVariablesError,
   VariableCollector,
   VariableDeserializationError,
   VariableMap,
   VariableScopeCollisionError,
+  type VariableSearchPageResponse,
   variableNamesFromSchema,
 } from '../src/runtime/typedVariables';
 
@@ -31,6 +35,14 @@ describe('variableNamesFromSchema', () => {
 
   it('returns an empty list for an empty schema', () => {
     expect(variableNamesFromSchema(z.object({}))).toEqual([]);
+  });
+
+  it('throws a clear TypedVariablesError when passed a non-schema value', () => {
+    // Simulates a JS caller (or an `any` cast) passing something that is not a Zod object.
+    // @ts-expect-error - intentionally invalid input
+    expect(() => variableNamesFromSchema(null)).toThrow(TypedVariablesError);
+    // @ts-expect-error - intentionally invalid input
+    expect(() => variableNamesFromSchema({ notAShape: true })).toThrow(TypedVariablesError);
   });
 });
 
@@ -216,5 +228,111 @@ describe('collectTypedVariables paging', () => {
     });
     expect(calls).toBe(0);
     expect(map.raw).toEqual({});
+  });
+});
+
+describe('createVariableSearchFetchPage', () => {
+  type Filter = { name: { $in: string[] }; processInstanceKey?: string };
+
+  /** A resolved cancelable request whose cancel() records invocation. */
+  function request(response: VariableSearchPageResponse): {
+    req: CancelableRequest<VariableSearchPageResponse>;
+    cancelled: () => boolean;
+  } {
+    let cancelled = false;
+    const req: CancelableRequest<VariableSearchPageResponse> = Object.assign(
+      Promise.resolve(response),
+      {
+        cancel: () => {
+          cancelled = true;
+        },
+      }
+    );
+    return { req, cancelled: () => cancelled };
+  }
+
+  it('builds the request input with the name filter, page cursor, and truncateValues=false', async () => {
+    const inputs: unknown[] = [];
+    const filter: Filter = { name: { $in: ['orderId', 'amount'] }, processInstanceKey: 'pi-1' };
+    const fetchPage = createVariableSearchFetchPage<Filter>({
+      filter,
+      limit: 25,
+      signal: new AbortController().signal,
+      search: (input) => {
+        inputs.push(input);
+        return request({
+          items: [{ name: 'orderId', value: '"A-1"', scopeKey: 'scope-1' }],
+          page: { endCursor: 'c1' },
+        }).req;
+      },
+    });
+
+    const first = await fetchPage(undefined);
+    expect(inputs[0]).toEqual({ filter, page: { limit: 25 }, truncateValues: false });
+    expect(first).toEqual({
+      items: [{ name: 'orderId', value: '"A-1"', scopeKey: 'scope-1' }],
+      endCursor: 'c1',
+    });
+
+    await fetchPage('c1');
+    expect(inputs[1]).toEqual({ filter, page: { after: 'c1', limit: 25 }, truncateValues: false });
+  });
+
+  it('stringifies non-string scopeKey values in mapped items', async () => {
+    const fetchPage = createVariableSearchFetchPage<Filter>({
+      filter: { name: { $in: ['a'] } },
+      limit: 10,
+      signal: new AbortController().signal,
+      search: () =>
+        request({ items: [{ name: 'a', value: '1', scopeKey: 12345 }], page: { endCursor: null } })
+          .req,
+    });
+    const result = await fetchPage(undefined);
+    expect(result.items[0]?.scopeKey).toBe('12345');
+  });
+
+  it('forwards outer cancellation to the in-flight page request', async () => {
+    const controller = new AbortController();
+    let cancelled = false;
+    let resolvePending: (v: VariableSearchPageResponse) => void = () => {};
+    const pending: CancelableRequest<VariableSearchPageResponse> = Object.assign(
+      new Promise<VariableSearchPageResponse>((resolve) => {
+        resolvePending = resolve;
+      }),
+      {
+        cancel: () => {
+          cancelled = true;
+          resolvePending({ items: [], page: { endCursor: null } });
+        },
+      }
+    );
+    const fetchPage = createVariableSearchFetchPage<Filter>({
+      filter: { name: { $in: ['a'] } },
+      limit: 10,
+      signal: controller.signal,
+      search: () => pending,
+    });
+
+    const inFlight = fetchPage(undefined);
+    controller.abort();
+    await inFlight;
+    expect(cancelled).toBe(true);
+  });
+
+  it('aborts before issuing a request when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let called = false;
+    const fetchPage = createVariableSearchFetchPage<Filter>({
+      filter: { name: { $in: ['a'] } },
+      limit: 10,
+      signal: controller.signal,
+      search: () => {
+        called = true;
+        return request({ items: [], page: { endCursor: null } }).req;
+      },
+    });
+    await expect(fetchPage(undefined)).rejects.toThrow();
+    expect(called).toBe(false);
   });
 });

--- a/tests/typed-variables.test.ts
+++ b/tests/typed-variables.test.ts
@@ -278,6 +278,23 @@ describe('createVariableSearchFetchPage', () => {
     expect(inputs[1]).toEqual({ filter, page: { after: 'c1', limit: 25 }, truncateValues: false });
   });
 
+  it('forwards an empty-string cursor as page.after (cursors are opaque)', async () => {
+    const inputs: unknown[] = [];
+    const filter: Filter = { name: { $in: ['a'] } };
+    const fetchPage = createVariableSearchFetchPage<Filter>({
+      filter,
+      limit: 10,
+      signal: new AbortController().signal,
+      search: (input) => {
+        inputs.push(input);
+        return request({ items: [], page: { endCursor: null } }).req;
+      },
+    });
+
+    await fetchPage('');
+    expect(inputs[0]).toEqual({ filter, page: { after: '', limit: 10 }, truncateValues: false });
+  });
+
   it('stringifies non-string scopeKey values in mapped items', async () => {
     const fetchPage = createVariableSearchFetchPage<Filter>({
       filter: { name: { $in: ['a'] } },
@@ -316,6 +333,43 @@ describe('createVariableSearchFetchPage', () => {
     const inFlight = fetchPage(undefined);
     controller.abort();
     await inFlight;
+    expect(cancelled).toBe(true);
+  });
+
+  it('cancels the in-flight request when the signal aborts before the listener is registered', async () => {
+    // Reproduce the race: throwIfAborted() does not throw, but the signal is already aborted by
+    // the time the abort listener would be attached (addEventListener never fires its callback).
+    // The explicit `signal.aborted` guard must still cancel the in-flight request.
+    const fakeSignal = {
+      aborted: true,
+      throwIfAborted() {
+        // no-op: simulates the window where abort happened *after* this check
+      },
+      addEventListener() {
+        // no-op: the abort event already fired, so the listener is never invoked
+      },
+      removeEventListener() {},
+    } as unknown as AbortSignal;
+
+    let cancelled = false;
+    const fetchPage = createVariableSearchFetchPage<Filter>({
+      filter: { name: { $in: ['a'] } },
+      limit: 10,
+      signal: fakeSignal,
+      search: () => {
+        const req: CancelableRequest<VariableSearchPageResponse> = Object.assign(
+          Promise.resolve<VariableSearchPageResponse>({ items: [], page: { endCursor: null } }),
+          {
+            cancel: () => {
+              cancelled = true;
+            },
+          }
+        );
+        return req;
+      },
+    });
+
+    await fetchPage(undefined);
     expect(cancelled).toBe(true);
   });
 

--- a/tests/typed-variables.test.ts
+++ b/tests/typed-variables.test.ts
@@ -415,4 +415,60 @@ describe('createVariableSearchFetchPage', () => {
     await expect(fetchPage(undefined)).rejects.toThrow();
     expect(called).toBe(false);
   });
+
+  it('throws an AbortError (not a TypeError) on runtimes lacking throwIfAborted, already aborted', async () => {
+    // Guards the whole class of runtimes (older browsers) where AbortSignal has no throwIfAborted
+    // method. Calling the missing method would throw a TypeError before any request; the fallback
+    // must instead throw an AbortError-shaped error and issue no request.
+    const fakeSignal = {
+      aborted: true,
+      reason: undefined,
+      addEventListener() {},
+      removeEventListener() {},
+      // intentionally NO throwIfAborted method
+    } as unknown as AbortSignal;
+
+    let called = false;
+    const fetchPage = createVariableSearchFetchPage<Filter>({
+      filter: { name: { $in: ['a'] } },
+      limit: 10,
+      signal: fakeSignal,
+      search: () => {
+        called = true;
+        return request({ items: [], page: { endCursor: null } }).req;
+      },
+    });
+
+    await expect(fetchPage(undefined)).rejects.toMatchObject({ name: 'AbortError' });
+    expect(called).toBe(false);
+  });
+
+  it('proceeds normally on runtimes lacking throwIfAborted when not aborted', async () => {
+    // Same missing-method runtime, but the signal is not aborted: the fallback must be a no-op and
+    // the request must be issued as usual.
+    const fakeSignal = {
+      aborted: false,
+      addEventListener() {},
+      removeEventListener() {},
+      // intentionally NO throwIfAborted method
+    } as unknown as AbortSignal;
+
+    let called = false;
+    const fetchPage = createVariableSearchFetchPage<Filter>({
+      filter: { name: { $in: ['a'] } },
+      limit: 10,
+      signal: fakeSignal,
+      search: () => {
+        called = true;
+        return request({
+          items: [{ name: 'a', value: '1', scopeKey: 's' }],
+          page: { endCursor: null },
+        }).req;
+      },
+    });
+
+    const result = await fetchPage(undefined);
+    expect(called).toBe(true);
+    expect(result.items[0]?.name).toBe('a');
+  });
 });


### PR DESCRIPTION
## Summary

Adds an ergonomic, DTO-driven way to fetch process variables and bind them to a [Zod](https://zod.dev) schema. The schema **is** the DTO: its keys are the exact variable names to fetch, and its shape drives validation.

```ts
import { z } from 'zod';

const OrderVariables = z.object({
  orderId: z.string(),
  amount: z.number().optional(),
});

const map = await client.searchVariablesAsDto(OrderVariables, { processInstanceKey });

if (map.has('amount')) console.log(map.get('amount')); // lenient access
const order = map.validate(); // strict: { orderId: string; amount?: number } or throws ZodError
```

## Design

This ports the typed-variable-map feature (originating from the Python SDK issue) to the TypeScript SDK, choosing an idiomatic Zod-schema-as-DTO design:

- **Memory-bounded paging** — only the declared variable names are queried (via a `name $in [...]` filter) and results page internally until every declared variable is found or the result set is exhausted, so memory stays bound by the DTO shape rather than the total number of variables on the instance.
- **Loud failures** — a variable found at more than one scope (with no `scopeKey` to disambiguate) raises `VariableScopeCollisionError`; a value that is not valid JSON raises `VariableDeserializationError`.
- **Native validation** — `validate()` parses collected values against the schema and either returns a fully-typed object or throws a standard `ZodError`.

## What's included

- `src/runtime/typedVariables.ts` — pure (I/O-free) core: `VariableMap`, `VariableCollector`, `collectTypedVariables`, `variableNamesFromSchema`, and the typed error classes.
- `searchVariablesAsDto<TSchema>()` ergonomic client method (added to the template, spliced into the generated client).
- Public exports from `src/index.ts`.
- 18 unit tests covering schema name extraction, lenient access, strict `validate()` (success / optional-absent / `ZodError` on missing required / `ZodError` on wrong type), first-value-wins collection, undeclared-name dropping, scope-collision, bad-JSON handling, and paging termination (early stop, null cursor, empty page, repeated-cursor guard, empty-schema no-fetch).
- README section + synced example.

## Validation

- 18/18 typed-variable unit tests pass
- `tsup --dts` dist build succeeds; method and all runtime symbols appear in the published declarations
- README in sync; Biome clean
- Generated diff is purely additive (`+77, -0`), preserving all injected `@example` docs

## Notes

The two commits follow the repo's source/gen split convention:
1. `feat:` — source (runtime module, tests, template, exports, README/example)
2. `chore(gen):` — regenerated `src/gen/CamundaClient.ts`
