### PR TITLE
fix(deps): bump camunda-schema-bundler to 2.4.3 for IterationId generation

### DIFF
--- a/examples/agent-instance.ts
+++ b/examples/agent-instance.ts
@@ -5,6 +5,7 @@ import {
   type AgentInstanceKey,
   createCamundaClient,
   type ElementInstanceKey,
+  type JobKey,
 } from '@camunda8/orchestration-cluster-api';
 
 //#region GetAgentInstance
@@ -80,8 +81,54 @@ async function updateAgentInstanceExample(
 }
 //#endregion UpdateAgentInstance
 
+//#region CreateAgentInstanceHistoryItem
+async function createAgentInstanceHistoryItemExample(
+  agentInstanceKey: AgentInstanceKey,
+  elementInstanceKey: ElementInstanceKey,
+  jobKey: JobKey,
+  jobLease: string
+) {
+  const camunda = createCamundaClient();
+
+  const result = await camunda.createAgentInstanceHistoryItem({
+    agentInstanceKey,
+    elementInstanceKey,
+    jobKey,
+    jobLease,
+    role: 'ASSISTANT',
+    content: [{ contentType: 'TEXT', text: 'How can I help you today?' }],
+    producedAt: new Date().toISOString(),
+  });
+
+  console.log(`Created history item: ${result.historyItemKey}`);
+}
+//#endregion CreateAgentInstanceHistoryItem
+
+//#region SearchAgentInstanceHistory
+async function searchAgentInstanceHistoryExample(agentInstanceKey: AgentInstanceKey) {
+  const camunda = createCamundaClient();
+
+  const result = await camunda.searchAgentInstanceHistory(
+    {
+      agentInstanceKey,
+      filter: { role: { $eq: 'ASSISTANT' } },
+      sort: [{ field: 'producedAt', order: 'ASC' }],
+      page: { limit: 20 },
+    },
+    { consistency: { waitUpToMs: 5000 } }
+  );
+
+  for (const item of result.items ?? []) {
+    console.log(`${item.historyItemKey} (${item.role})`);
+  }
+  console.log(`Total: ${result.page.totalItems}`);
+}
+//#endregion SearchAgentInstanceHistory
+
 // Suppress "declared but never read"
 void getAgentInstanceExample;
 void searchAgentInstancesExample;
 void createAgentInstanceExample;
 void updateAgentInstanceExample;
+void createAgentInstanceHistoryItemExample;
+void searchAgentInstanceHistoryExample;

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -20,6 +20,20 @@
       "label": "Create an agent instance"
     }
   ],
+  "createAgentInstanceHistoryItem": [
+    {
+      "file": "agent-instance.ts",
+      "region": "CreateAgentInstanceHistoryItem",
+      "label": "Append an agent instance history item"
+    }
+  ],
+  "searchAgentInstanceHistory": [
+    {
+      "file": "agent-instance.ts",
+      "region": "SearchAgentInstanceHistory",
+      "label": "Search agent instance history"
+    }
+  ],
   "updateAgentInstance": [
     {
       "file": "agent-instance.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^20.14.9",
         "@types/single-line-log": "^1.1.2",
         "assert-json-body": "^1.5.0",
-        "camunda-schema-bundler": "^2.4.1",
+        "camunda-schema-bundler": "^2.4.3",
         "chalk": "^5.6.2",
         "fp-ts": "^2.16.11",
         "husky": "^9.0.11",
@@ -2817,9 +2817,9 @@
       }
     },
     "node_modules/camunda-schema-bundler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/camunda-schema-bundler/-/camunda-schema-bundler-2.4.1.tgz",
-      "integrity": "sha512-fG/7I30Nhtb1XPfo1pboAVp9mhO62JIso8XNc9N4AiZk0n2g96ht1bhz0jt27zmD+/b/wXPOGBuYyhzY4bna9w==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/camunda-schema-bundler/-/camunda-schema-bundler-2.4.3.tgz",
+      "integrity": "sha512-UFLczhFGZ2UYXEtoxT5/FEPca+5VDXibbMAF7FLFviqinhAV8HfLs8gPZI6V670DIYVZzq3tdbniWTIeANHjIQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@types/node": "^20.14.9",
     "@types/single-line-log": "^1.1.2",
     "assert-json-body": "^1.5.0",
-    "camunda-schema-bundler": "^2.4.1",
+    "camunda-schema-bundler": "^2.4.3",
     "chalk": "^5.6.2",
     "fp-ts": "^2.16.11",
     "husky": "^9.0.11",


### PR DESCRIPTION
## What

Bumps `camunda-schema-bundler` from `^2.4.1` to `^2.4.3` (lockfile re-resolved `2.4.1` → `2.4.3`).

## Why

Bundler 2.4.3 excludes non-string-typed semantic keys from metadata. Upstream `camunda/camunda` added an `IterationId` semantic key but typed it as `integer` (`format: int32`) while retaining its `x-semantic-type` annotation. With bundler 2.4.1, the branding plugin emitted a branded string namespace over `type IterationId = number`, producing a `TS2322` error at `src/gen/types.gen.ts` that **blocked SDK generation and release**.

With 2.4.3, `IterationId` generates cleanly as `export type IterationId = number;` with no branded namespace.

## Verification

- Installed bundler confirmed at `2.4.3`.
- Re-bundled the upstream spec → `semanticKeys=41` (was 42; `IterationId` now correctly excluded).
- Full generation pipeline runs; the example type-check hook passes (`✓ API examples type-check passed`).
- `IterationId` regenerates as `export type IterationId = number;` — the `TS2322` blocker is gone.

No generated `src/gen` drift is committed: release CI regenerates `src/gen` against the upstream spec, so this PR stays a minimal dependency bump.