### PR TITLE
fix: adopt upstream wait-state details union in example

### DIFF
--- a/examples/extended-operations.ts
+++ b/examples/extended-operations.ts
@@ -380,7 +380,12 @@ async function searchElementInstanceWaitStatesExample(processInstanceKey: Proces
   );
 
   for (const waitState of result.items ?? []) {
-    console.log(`${waitState.elementId}: ${waitState.waitStateType}`);
+    const { details } = waitState;
+    const description =
+      details.waitStateType === 'JOB'
+        ? `waiting on job '${details.jobType}'`
+        : `waiting for message '${details.messageName}'`;
+    console.log(`${waitState.elementId}: ${description}`);
   }
 }
 //#endregion SearchElementInstanceWaitStates


### PR DESCRIPTION
## Problem

The generation pipeline''s example typecheck (`hooks/post/950-typecheck-examples.ts`) fails:

```
examples/extended-operations.ts: error TS2339:
Property ''waitStateType'' does not exist on type ''ElementInstanceWaitStateResult''.
```

CI regenerates the SDK from the live upstream spec on every run (`npm run build` → `generate`). Upstream `camunda/camunda@main` restructured `ElementInstanceWaitStateResult`, replacing the flat `waitStateType` field with a single polymorphic `details` (`WaitStateDetails`) discriminated union (`JOB` / `MESSAGE` variants). The committed example still read `waitState.waitStateType`, so it no longer type-checks against the regenerated SDK.

This is the JS counterpart of camunda/orchestration-cluster-api-csharp#254.

## Fix

Narrow on the new `details` union in the `SearchElementInstanceWaitStates` example:

```ts
const { details } = waitState;
const description =
  details.waitStateType === ''JOB''
    ? `waiting on job ''${details.jobType}''`
    : `waiting for message ''${details.messageName}''`;
```

Only the example is committed — `src/gen`, the bundled spec, and the README are all regenerated by CI (`npm run build`), and generation drift is non-blocking, so they''re intentionally left for CI to produce on Linux.

## Verification

Ran the generation pipeline locally against the live spec: `hooks/post/450-inject-examples` + `950-typecheck-examples` pass (`✓ API examples type-check passed`), and `sync-readme:check` passes (the wait-state snippet is not embedded in the README, so no README change is needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)