### PR TITLE
test: expect error status code, not text

### DIFF
--- a/tests-integration/eventual-consistency.test.ts
+++ b/tests-integration/eventual-consistency.test.ts
@@ -86,12 +86,7 @@ describe('eventual consistency', () => {
       },
       { consistency: { waitUpToMs: 0 } }
     );
-    try {
-      await res;
-    } catch (e) {
-      console.error(e)
-    }
-    await expect(res).rejects.toMatchObject({ status: 404 });
+    await expect(res).rejects.toHaveProperty('status', 404);
   });
 
   it('throws EventualConsistencyTimeoutError when nothing is found and waitUpToMs is 1_000', {

--- a/tests-integration/eventual-consistency.test.ts
+++ b/tests-integration/eventual-consistency.test.ts
@@ -86,7 +86,12 @@ describe('eventual consistency', () => {
       },
       { consistency: { waitUpToMs: 0 } }
     );
-    await expect(res).rejects.toThrowError('NOT_FOUND');
+    try {
+      await res;
+    } catch (e) {
+      console.error(e)
+    }
+    await expect(res).rejects.toMatchObject({ status: 404 });
   });
 
   it('throws EventualConsistencyTimeoutError when nothing is found and waitUpToMs is 1_000', {

--- a/tests-integration/jobWorker/jobWorkerThrowError.test.ts
+++ b/tests-integration/jobWorker/jobWorkerThrowError.test.ts
@@ -10,9 +10,30 @@ test(
       './tests-integration/fixtures/Client-ThrowError.bpmn',
     ]);
     const { processDefinitionKey } = res.processes[0];
-    await camunda.cancelProcessInstancesBatchOperation(
+
+    // Cancel any leftover instances of this definition from prior runs, then wait
+    // for the batch operation to reach a terminal state BEFORE creating the new
+    // instance. cancelProcessInstancesBatchOperation is asynchronous: it returns a
+    // batchOperationKey immediately and cancels matching instances over a
+    // server-side window. Because the filter matches on processDefinitionKey alone,
+    // an in-flight batch can cancel the instance we create below, removing its
+    // sad-flow job so awaitCompletion never resolves. Waiting for a terminal state
+    // is the deterministic signal that cancellation can no longer affect the new
+    // instance.
+    const { batchOperationKey } = await camunda.cancelProcessInstancesBatchOperation(
       { filter: { processDefinitionKey } },
       { consistency: { waitUpToMs: 0 } }
+    );
+    const TERMINAL_BATCH_STATES = ['COMPLETED', 'PARTIALLY_COMPLETED', 'CANCELED', 'FAILED'];
+    await camunda.getBatchOperation(
+      { batchOperationKey },
+      {
+        consistency: {
+          waitUpToMs: 15_000,
+          pollIntervalMs: 200,
+          predicate: (batch) => TERMINAL_BATCH_STATES.includes(batch.state),
+        },
+      }
     );
 
     camunda.createJobWorker({
@@ -42,7 +63,7 @@ test(
     expect(result.variables.bpmnErrorCaught).toBe(true);
     camunda.stopAllWorkers();
   },
-  { timeout: 20_000 }
+  { timeout: 60_000 }
 );
 
 // test.runIf(allowAny([{ deployment: 'saas' }, { deployment: 'self-managed' }]))(

--- a/tests-integration/jobWorker/jobWorkerThrowError.test.ts
+++ b/tests-integration/jobWorker/jobWorkerThrowError.test.ts
@@ -69,14 +69,19 @@ test(
       maxParallelJobs: 1,
       jobTimeoutMs: 10_000,
     });
-    const result = await camunda.createProcessInstance({
-      processDefinitionKey,
-      requestTimeout: 20_000,
-      variables: {},
-      awaitCompletion: true,
-    });
-    expect(result.variables.bpmnErrorCaught).toBe(true);
-    camunda.stopAllWorkers();
+    try {
+      const result = await camunda.createProcessInstance({
+        processDefinitionKey,
+        requestTimeout: 20_000,
+        variables: {},
+        awaitCompletion: true,
+      });
+      expect(result.variables.bpmnErrorCaught).toBe(true);
+    } finally {
+      // Always stop workers, even if awaitCompletion throws (timeout/transient
+      // cluster error), so leftover workers cannot interfere with later tests.
+      camunda.stopAllWorkers();
+    }
   },
   { timeout: 60_000 }
 );

--- a/tests-integration/jobWorker/jobWorkerThrowError.test.ts
+++ b/tests-integration/jobWorker/jobWorkerThrowError.test.ts
@@ -11,29 +11,44 @@ test(
     ]);
     const { processDefinitionKey } = res.processes[0];
 
-    // Cancel any leftover instances of this definition from prior runs, then wait
-    // for the batch operation to reach a terminal state BEFORE creating the new
-    // instance. cancelProcessInstancesBatchOperation is asynchronous: it returns a
-    // batchOperationKey immediately and cancels matching instances over a
-    // server-side window. Because the filter matches on processDefinitionKey alone,
-    // an in-flight batch can cancel the instance we create below, removing its
-    // sad-flow job so awaitCompletion never resolves. Waiting for a terminal state
-    // is the deterministic signal that cancellation can no longer affect the new
-    // instance.
-    const { batchOperationKey } = await camunda.cancelProcessInstancesBatchOperation(
-      { filter: { processDefinitionKey } },
-      { consistency: { waitUpToMs: 0 } }
-    );
-    const TERMINAL_BATCH_STATES = ['COMPLETED', 'PARTIALLY_COMPLETED', 'CANCELED', 'FAILED'];
-    await camunda.getBatchOperation(
-      { batchOperationKey },
-      {
-        consistency: {
-          waitUpToMs: 15_000,
-          pollIntervalMs: 200,
-          predicate: (batch) => TERMINAL_BATCH_STATES.includes(batch.state),
+    // Test- and test-run isolation: deterministically cancel any leftover ACTIVE
+    // instances of this definition from prior runs BEFORE creating the new instance.
+    //
+    // We snapshot the currently-active instances and cancel each one explicitly by
+    // key, rather than firing cancelProcessInstancesBatchOperation. A batch operation
+    // is asynchronous and matches on processDefinitionKey over a server-side execution
+    // window; when a backlog of active instances widens that window, the batch can
+    // cancel the instance we create below — removing its sad-flow job so
+    // awaitCompletion never resolves (a 20s timeout). Per-key cancellation targets
+    // only instances that existed at snapshot time, never the one created afterwards,
+    // so it isolates the run deterministically regardless of backlog size.
+    //
+    // The search uses waitUpToMs: 0 (a single read, no eventual-consistency wait):
+    // the default search predicate blocks until items are non-empty, which would time
+    // out on a clean run or on the final empty page. Snapshot all keys read-only
+    // first (cursors stay valid because reads don't mutate), then cancel.
+    type InstanceSearch = Awaited<ReturnType<typeof camunda.searchProcessInstances>>;
+    const leftover: InstanceSearch['items'] = [];
+    let after: InstanceSearch['page']['endCursor'] | undefined;
+    do {
+      const existing = await camunda.searchProcessInstances(
+        {
+          filter: { processDefinitionKey, state: 'ACTIVE' },
+          page: after ? { after, limit: 100 } : { limit: 100 },
         },
-      }
+        { consistency: { waitUpToMs: 0 } }
+      );
+      leftover.push(...existing.items);
+      after = existing.page.endCursor ?? undefined;
+    } while (after);
+    await Promise.all(
+      leftover.map((instance) =>
+        // Tolerate instances that reached a terminal state between snapshot and
+        // cancel — they are no longer a concern for isolation.
+        camunda
+          .cancelProcessInstance({ processInstanceKey: instance.processInstanceKey })
+          .catch(() => undefined)
+      )
     );
 
     camunda.createJobWorker({


### PR DESCRIPTION
Changes a test to expect a status code and not the error text. 

Hardens a test that failed during the CI check. Seems to have become intermittent? (Strange, it was stable for six months).