### PR TITLE
test: use second-argument options signature for vitest 4 compatibility

### DIFF
--- a/tests-integration/jobWorker/jobWorkerThrowError.test.ts
+++ b/tests-integration/jobWorker/jobWorkerThrowError.test.ts
@@ -3,6 +3,7 @@ import { createCamundaClient } from '../../dist';
 
 test(
   'Throws a business error that is caught in the process',
+  { timeout: 60_000 },
   async () => {
     const camunda = createCamundaClient();
 
@@ -82,8 +83,7 @@ test(
       // cluster error), so leftover workers cannot interfere with later tests.
       camunda.stopAllWorkers();
     }
-  },
-  { timeout: 60_000 }
+  }
 );
 
 // test.runIf(allowAny([{ deployment: 'saas' }, { deployment: 'self-managed' }]))(


### PR DESCRIPTION
## Problem

The vitest bump PR (#254, vitest 3→4) fails at test collection:

```
TypeError: Signature "test(name, fn, { ... })" was deprecated in Vitest 3 and removed in Vitest 4.
Please, provide options as a second argument instead.
 ❯ tests-integration/jobWorker/jobWorkerThrowError.test.ts:4:1
```

Vitest 4 removed the third-argument options form. `jobWorkerThrowError.test.ts` was the only file repo-wide still using it (`{ timeout: 60_000 }` after the callback).

## Fix

Move the options object to the second argument: `test(name, { timeout: 60_000 }, fn)`. This form works on **both** vitest 3 and 4, so it can land on `main` now and unblocks #254 on rebase — no behaviour change.

A repo-wide scan confirms this was the only remaining occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)