### PR TITLE
ci: auto-merge patch updates as well as minor

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,8 +21,8 @@
       "enabled": false
     },
     {
-      "description": "Auto-merge minor updates once CI is green.",
-      "matchUpdateTypes": ["minor"],
+      "description": "Auto-merge minor and patch updates once CI is green.",
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
   ],


### PR DESCRIPTION
## What

Extends the Renovate automerge rule from **minor-only** to **minor + patch**:

```diff
-      "description": "Auto-merge minor updates once CI is green.",
-      "matchUpdateTypes": ["minor"],
+      "description": "Auto-merge minor and patch updates once CI is green.",
+      "matchUpdateTypes": ["minor", "patch"],
```

## Why

Patch updates are the safest update class, but under minor-only they all queued for manual merge (e.g. orchestration-cluster-api-js#310, a `camunda-schema-bundler` patch bump showing "Automerge: Disabled by config"). CI remains the gate — Renovate only merges on green checks. Major updates stay manual.

Side effect worth knowing: on stable maintenance branches patch is the *only* allowed update type, so those PRs now automerge too.

(Same change applied to all four repos: orchestration-cluster-api-{csharp,python,js}, camunda-8-js-sdk.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
