### PR TITLE
docs: add changeClusterMode example and operation-map entry

### DIFF
--- a/examples/client.ts
+++ b/examples/client.ts
@@ -66,6 +66,25 @@ async function getTopologyExample() {
 }
 //#endregion GetTopology
 
+//#region ChangeClusterMode
+async function changeClusterModeExample() {
+  const camunda = createCamundaClient();
+
+  // Transition the cluster into recovery mode. Pass `dryRun: true` to validate
+  // the request and inspect the resulting plan without applying it. Omit it (or
+  // set it to false) to actually trigger the transition.
+  const change = await camunda.changeClusterMode({
+    mode: 'RECOVERING',
+    dryRun: true,
+  });
+
+  console.log(`Cluster change ${change.changeId}:`);
+  for (const op of change.plannedChanges) {
+    console.log(`  ${op.operation}${op.mode ? ` -> ${op.mode}` : ''}`);
+  }
+}
+//#endregion ChangeClusterMode
+
 //#region ResultClient
 async function resultClientExample() {
   const camunda = createCamundaResultClient({
@@ -182,6 +201,7 @@ void createClientExample;
 void createClientWithConfigExample;
 void createClientOAuthExample;
 void getTopologyExample;
+void changeClusterModeExample;
 void resultClientExample;
 void customFetchExample;
 void configExample;

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -48,6 +48,13 @@
       "label": "Get cluster topology"
     }
   ],
+  "changeClusterMode": [
+    {
+      "file": "client.ts",
+      "region": "ChangeClusterMode",
+      "label": "Change cluster mode"
+    }
+  ],
   "createProcessInstance": [
     {
       "file": "process-instance.ts",


### PR DESCRIPTION
## What

Adds example coverage for the `changeClusterMode` operation (`PATCH /mode`, tag `Recovery`, added in Camunda 8.10).

- Adds a compilable, type-checked example region `ChangeClusterMode` in [`examples/client.ts`](examples/client.ts) mirroring the existing `getTopology` example.
- Registers the operation in [`examples/operation-map.json`](examples/operation-map.json) so example coverage is complete.

## Why

`changeClusterMode` is a new operation with no example coverage, which is flagged by the scheduled coverage check. Closes #333.

## Notes

- Generated sources (`src/gen/*`) are intentionally **not** committed — CI regenerates them from the upstream spec on every build, and the drift-detection step is non-blocking. Committing a full regeneration here would pull in unrelated upstream spec drift. The example was validated against a local regeneration (`npm run build` → `npx tsc -p examples/tsconfig.json` passes; coverage check reports 100%).
