### PR TITLE
refactor: source config defaults from SCHEMA in hydration (#145)

### DIFF
--- a/src/runtime/configSchema.ts
+++ b/src/runtime/configSchema.ts
@@ -6,7 +6,8 @@ export const SCHEMA = {
   CAMUNDA_REST_ADDRESS: {
     type: 'string',
     default: 'http://localhost:8080/v2',
-    doc: 'Base REST endpoint address.',
+    aliases: ['ZEEBE_REST_ADDRESS'],
+    doc: 'Base REST endpoint address. Legacy alias: ZEEBE_REST_ADDRESS (used only when CAMUNDA_REST_ADDRESS is unset).',
   },
   CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS: {
     desc: 'Maximum total HTTP attempts (including the initial attempt) for transient failures (429,503, network).',
@@ -256,6 +257,10 @@ export function isSecret(key: EnvVarKey): boolean {
 }
 export function requiredWhen(key: EnvVarKey): { key: EnvVarKey; equals: string } | undefined {
   return (SCHEMA as any)[key].requiredWhen;
+}
+// Legacy env var names accepted as fallbacks for a canonical key (declared in SCHEMA).
+export function aliases(key: EnvVarKey): readonly string[] {
+  return (SCHEMA as any)[key].aliases ?? [];
 }
 export function defaultValue(key: EnvVarKey): any {
   return (SCHEMA as any)[key].default;

--- a/src/runtime/jobWorker.ts
+++ b/src/runtime/jobWorker.ts
@@ -103,13 +103,16 @@ export class JobWorker {
 
   constructor(client: CamundaClient, cfg: JobWorkerConfig) {
     this._client = client;
+    // Nullish-coalesce each defaulted field so an explicitly-passed `undefined`
+    // cannot wipe out a required runtime default (a plain `{...defaults, ...cfg}`
+    // spread would let `maxParallelJobs: undefined` override the default).
     this._cfg = {
-      pollIntervalMs: 1,
-      autoStart: true,
-      validateSchemas: false,
-      maxParallelJobs: 10,
-      jobTimeoutMs: 60_000,
       ...cfg,
+      pollIntervalMs: cfg.pollIntervalMs ?? 1,
+      autoStart: cfg.autoStart ?? true,
+      validateSchemas: cfg.validateSchemas ?? false,
+      maxParallelJobs: cfg.maxParallelJobs ?? 10,
+      jobTimeoutMs: cfg.jobTimeoutMs ?? 60_000,
     };
     this._maxParallelJobs = this._cfg.maxParallelJobs;
     this._jobTimeoutMs = this._cfg.jobTimeoutMs;

--- a/src/runtime/jobWorker.ts
+++ b/src/runtime/jobWorker.ts
@@ -59,6 +59,20 @@ export interface JobWorkerConfig<
   validateSchemas?: boolean;
 }
 
+/**
+ * Internal shape after constructor defaults are applied: the defaulted fields
+ * become required so the class body needs no non-null assertions on them. The
+ * constructor's spread literal is checked against this type, so adding a new
+ * defaulted field here without a matching default in the spread is a compile error.
+ */
+type ResolvedJobWorkerConfig = JobWorkerConfig & {
+  pollIntervalMs: number;
+  autoStart: boolean;
+  validateSchemas: boolean;
+  maxParallelJobs: number;
+  jobTimeoutMs: number;
+};
+
 type InferOrUnknown<T extends z.ZodTypeAny | undefined> = T extends z.ZodTypeAny
   ? z.infer<T>
   : Record<string, unknown>;
@@ -77,7 +91,7 @@ const DEFAULT_LONGPOLL_TIMEOUT = 0;
 
 export class JobWorker {
   private _client: CamundaClient;
-  private _cfg: JobWorkerConfig;
+  private _cfg: ResolvedJobWorkerConfig;
   private _maxParallelJobs: number;
   private _jobTimeoutMs: number;
   private _name: string;
@@ -97,8 +111,8 @@ export class JobWorker {
       jobTimeoutMs: 60_000,
       ...cfg,
     };
-    this._maxParallelJobs = this._cfg.maxParallelJobs!;
-    this._jobTimeoutMs = this._cfg.jobTimeoutMs!;
+    this._maxParallelJobs = this._cfg.maxParallelJobs;
+    this._jobTimeoutMs = this._cfg.jobTimeoutMs;
     this._name = cfg.workerName || `worker-${cfg.jobType}-${++_workerCounter}`;
     this._log = this._client.logger().scope(`worker:${this._name}`);
     if (cfg.maxBackoffTimeMs !== undefined) {
@@ -207,12 +221,12 @@ export class JobWorker {
     if (this._stopped) return;
     // If at capacity, defer
     if (this._activeJobs >= this._maxParallelJobs) {
-      this._scheduleNext(this._cfg.pollIntervalMs!);
+      this._scheduleNext(this._cfg.pollIntervalMs);
       return;
     }
     const batchSize = this._maxParallelJobs - this._activeJobs;
     if (batchSize <= 0) {
-      this._scheduleNext(this._cfg.pollIntervalMs!);
+      this._scheduleNext(this._cfg.pollIntervalMs);
       return;
     }
     // Activation body shape inferred – using common fields
@@ -244,12 +258,12 @@ export class JobWorker {
       } else {
         this._log.error('activation.error', e);
       }
-      this._scheduleNext(this._cfg.pollIntervalMs!);
+      this._scheduleNext(this._cfg.pollIntervalMs);
       return;
     }
     if (!result || result.length === 0) {
       // No jobs – simply schedule next poll
-      this._scheduleNext(this._cfg.pollIntervalMs!);
+      this._scheduleNext(this._cfg.pollIntervalMs);
       return;
     }
     this._activeJobs += result.length;

--- a/src/runtime/threadedJobWorker.ts
+++ b/src/runtime/threadedJobWorker.ts
@@ -91,6 +91,20 @@ export interface ThreadedJobWorkerConfig<
   threadPoolSize?: number;
 }
 
+/**
+ * Internal shape after constructor defaults are applied: the defaulted fields
+ * become required so the class body needs no non-null assertions on them. The
+ * constructor's spread literal is checked against this type, so adding a new
+ * defaulted field here without a matching default in the spread is a compile error.
+ */
+type ResolvedThreadedJobWorkerConfig = ThreadedJobWorkerConfig & {
+  pollIntervalMs: number;
+  autoStart: boolean;
+  validateSchemas: boolean;
+  maxParallelJobs: number;
+  jobTimeoutMs: number;
+};
+
 let _workerCounter = 0;
 
 const DEFAULT_LONGPOLL_TIMEOUT = 0;
@@ -106,7 +120,7 @@ const DEFAULT_LONGPOLL_TIMEOUT = 0;
 export class ThreadedJobWorker {
   private _client: CamundaClient;
   private _pool: ThreadPool;
-  private _cfg: ThreadedJobWorkerConfig;
+  private _cfg: ResolvedThreadedJobWorkerConfig;
   private _maxParallelJobs: number;
   private _jobTimeoutMs: number;
   private _name: string;
@@ -128,8 +142,8 @@ export class ThreadedJobWorker {
       jobTimeoutMs: 60_000,
       ...cfg,
     };
-    this._maxParallelJobs = this._cfg.maxParallelJobs!;
-    this._jobTimeoutMs = this._cfg.jobTimeoutMs!;
+    this._maxParallelJobs = this._cfg.maxParallelJobs;
+    this._jobTimeoutMs = this._cfg.jobTimeoutMs;
     this._name = cfg.workerName || `threaded-worker-${cfg.jobType}-${++_workerCounter}`;
     this._log = this._client.logger().scope(`worker:${this._name}`);
 
@@ -344,7 +358,7 @@ export class ThreadedJobWorker {
     // Ensure shared thread pool is ready before polling
     await this._pool.ready;
     if (this._activeJobs >= this._maxParallelJobs) {
-      this._scheduleNext(this._cfg.pollIntervalMs!);
+      this._scheduleNext(this._cfg.pollIntervalMs);
       return;
     }
     // Activate up to the concurrency headroom. Jobs that arrive when all
@@ -352,7 +366,7 @@ export class ThreadedJobWorker {
     // as threads become idle, keeping the pipeline full.
     const batchSize = this._maxParallelJobs - this._activeJobs;
     if (batchSize <= 0) {
-      this._scheduleNext(this._cfg.pollIntervalMs!);
+      this._scheduleNext(this._cfg.pollIntervalMs);
       return;
     }
     const body = {
@@ -381,11 +395,11 @@ export class ThreadedJobWorker {
       } else {
         this._log.error('activation.error', e);
       }
-      this._scheduleNext(this._cfg.pollIntervalMs!);
+      this._scheduleNext(this._cfg.pollIntervalMs);
       return;
     }
     if (!result || result.length === 0) {
-      this._scheduleNext(this._cfg.pollIntervalMs!);
+      this._scheduleNext(this._cfg.pollIntervalMs);
       return;
     }
     this._activeJobs += result.length;

--- a/src/runtime/threadedJobWorker.ts
+++ b/src/runtime/threadedJobWorker.ts
@@ -134,13 +134,16 @@ export class ThreadedJobWorker {
   constructor(client: CamundaClient, pool: ThreadPool, cfg: ThreadedJobWorkerConfig) {
     this._client = client;
     this._pool = pool;
+    // Nullish-coalesce each defaulted field so an explicitly-passed `undefined`
+    // cannot wipe out a required runtime default (a plain `{...defaults, ...cfg}`
+    // spread would let `maxParallelJobs: undefined` override the default).
     this._cfg = {
-      pollIntervalMs: 1,
-      autoStart: true,
-      validateSchemas: false,
-      maxParallelJobs: 10,
-      jobTimeoutMs: 60_000,
       ...cfg,
+      pollIntervalMs: cfg.pollIntervalMs ?? 1,
+      autoStart: cfg.autoStart ?? true,
+      validateSchemas: cfg.validateSchemas ?? false,
+      maxParallelJobs: cfg.maxParallelJobs ?? 10,
+      jobTimeoutMs: cfg.jobTimeoutMs ?? 60_000,
     };
     this._maxParallelJobs = this._cfg.maxParallelJobs;
     this._jobTimeoutMs = this._cfg.jobTimeoutMs;

--- a/src/runtime/unifiedConfiguration.ts
+++ b/src/runtime/unifiedConfiguration.ts
@@ -441,7 +441,13 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
     if (d !== undefined) return String(d);
     throw new Error(`Internal configuration error: no value or schema default for ${k}`);
   };
-  const reqInt = (k: EnvVarKey): number => parseInt(reqStr(k), 10);
+  const reqInt = (k: EnvVarKey): number => {
+    const n = parseInt(reqStr(k), 10);
+    if (Number.isNaN(n)) {
+      throw new Error(`Internal configuration error: ${k} is not a valid integer`);
+    }
+    return n;
+  };
   const reqBool = (k: EnvVarKey): boolean => {
     // Prefer the already-typed value from typed-env; only fall back to parsing the
     // canonical string if a typed boolean is not available (avoids a redundant
@@ -651,13 +657,10 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
       profile,
       observeOnly: profile === 'LEGACY',
       initialMax: reqInt('CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX'),
-      softFactor: Math.min(
-        1,
-        Math.max(0.01, (reqInt('CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR') || 70) / 100)
-      ),
+      softFactor: Math.min(1, Math.max(0.01, reqInt('CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR') / 100)),
       severeFactor: Math.min(
         1,
-        Math.max(0.01, (reqInt('CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR') || 50) / 100)
+        Math.max(0.01, reqInt('CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR') / 100)
       ),
       recoveryIntervalMs: reqInt('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS'),
       recoveryStep: reqInt('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP'),
@@ -667,7 +670,7 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
       maxWaiters: reqInt('CAMUNDA_SDK_BACKPRESSURE_MAX_WAITERS'),
       healthyRecoveryMultiplier: Math.max(
         1,
-        (reqInt('CAMUNDA_SDK_BACKPRESSURE_HEALTHY_RECOVERY_MULTIPLIER') || 150) / 100
+        reqInt('CAMUNDA_SDK_BACKPRESSURE_HEALTHY_RECOVERY_MULTIPLIER') / 100
       ),
       unlimitedAfterHealthyMs: reqInt('CAMUNDA_SDK_BACKPRESSURE_UNLIMITED_AFTER_HEALTHY_MS'),
     },

--- a/src/runtime/unifiedConfiguration.ts
+++ b/src/runtime/unifiedConfiguration.ts
@@ -398,20 +398,6 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
     }
   }
 
-  // Implicit auth strategy inference: if OAUTH URL provided and no explicit strategy, default to OAUTH
-  if (
-    (envInput.CAMUNDA_AUTH_STRATEGY === undefined ||
-      envInput.CAMUNDA_AUTH_STRATEGY.trim() === '') &&
-    envInput.CAMUNDA_OAUTH_URL !== undefined &&
-    envInput.CAMUNDA_OAUTH_URL.trim() !== '' &&
-    envInput.CAMUNDA_CLIENT_ID !== undefined &&
-    envInput.CAMUNDA_CLIENT_ID.trim() !== '' &&
-    envInput.CAMUNDA_CLIENT_SECRET !== undefined &&
-    envInput.CAMUNDA_CLIENT_SECRET.trim() !== ''
-  ) {
-    envInput.CAMUNDA_AUTH_STRATEGY = 'OAUTH';
-  }
-
   // Run typed-env (will not throw for our parser-based validation; parseErrors collects issues)
   let envTyped: Record<string, any> = {};
   envTyped = createEnv(typedEnvSchema, { env: envInput });
@@ -431,9 +417,10 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
     }
   }
 
-  // Post-default inference safeguard: if auth strategy still NONE (default applied) but OAuth URL provided
-  // and user did not explicitly set a strategy, infer OAUTH. This covers cases where earlier inference
-  // might be overridden by schema default application.
+  // Auth strategy inference (single post-hydration transform): if the user did not
+  // explicitly set a strategy and OAuth URL + client id + secret are all present,
+  // infer OAUTH. Consolidated here so there is exactly one place that decides the
+  // strategy (previously duplicated as a pre-typed-env pass over envInput).
   if (
     !userSetStrategy &&
     rawMap.CAMUNDA_AUTH_STRATEGY === 'NONE' &&
@@ -455,7 +442,14 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
     throw new Error(`Internal configuration error: no value or schema default for ${k}`);
   };
   const reqInt = (k: EnvVarKey): number => parseInt(reqStr(k), 10);
-  const reqBool = (k: EnvVarKey): boolean => reqStr(k).trim().toLowerCase() === 'true';
+  const reqBool = (k: EnvVarKey): boolean => {
+    // Prefer the already-typed value from typed-env; only fall back to parsing the
+    // canonical string if a typed boolean is not available (avoids a redundant
+    // boolean -> string -> boolean round-trip).
+    const typed = envTyped[k];
+    if (typeof typed === 'boolean') return typed;
+    return reqStr(k).trim().toLowerCase() === 'true';
+  };
 
   // Parse primitives (int, boolean, enum normalization) replicating original semantics
   const authStrategyRaw = reqStr('CAMUNDA_AUTH_STRATEGY');

--- a/src/runtime/unifiedConfiguration.ts
+++ b/src/runtime/unifiedConfiguration.ts
@@ -7,6 +7,7 @@
 import path from 'node:path';
 import { createEnv } from 'typed-env';
 import {
+  aliases as aliasesMeta,
   allKeys,
   defaultValue,
   type EnvOverrides,
@@ -384,13 +385,17 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
     envInput.CAMUNDA_SUPPORT_LOG_ENABLED = envInput.CAMUNDA_SUPPORT_LOGGER;
   }
 
-  // Alias: accept ZEEBE_REST_ADDRESS as CAMUNDA_REST_ADDRESS (if primary unset)
-  if (
-    envInput.CAMUNDA_REST_ADDRESS === undefined &&
-    baseEnv.ZEEBE_REST_ADDRESS !== undefined &&
-    baseEnv.ZEEBE_REST_ADDRESS!.trim() !== ''
-  ) {
-    envInput.CAMUNDA_REST_ADDRESS = baseEnv.ZEEBE_REST_ADDRESS!.trim();
+  // Aliases: accept schema-declared legacy env var names as fallbacks when the
+  // canonical key is unset (e.g. ZEEBE_REST_ADDRESS -> CAMUNDA_REST_ADDRESS).
+  for (const k of allKeys()) {
+    if (envInput[k] !== undefined) continue;
+    for (const alias of aliasesMeta(k)) {
+      const aliasVal = baseEnv[alias];
+      if (aliasVal !== undefined && aliasVal.trim() !== '') {
+        envInput[k] = aliasVal.trim();
+        break;
+      }
+    }
   }
 
   // Implicit auth strategy inference: if OAUTH URL provided and no explicit strategy, default to OAUTH
@@ -454,7 +459,9 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
 
   // Parse primitives (int, boolean, enum normalization) replicating original semantics
   const authStrategyRaw = reqStr('CAMUNDA_AUTH_STRATEGY');
-  const authStrategy = authStrategyRaw.trim().toUpperCase();
+  // The enum parser already canonicalizes to the schema casing (uppercase), so no
+  // re-normalization is needed here.
+  const authStrategy = authStrategyRaw;
   if (!['NONE', 'OAUTH', 'BASIC'].includes(authStrategy)) {
     errors.push({
       code: ConfigErrorCode.CONFIG_INVALID_ENUM,
@@ -555,7 +562,8 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
     }
   }
   // Apply backpressure profile defaults if individual vars not explicitly provided.
-  const profile = reqStr('CAMUNDA_SDK_BACKPRESSURE_PROFILE').toUpperCase();
+  // The enum parser already canonicalizes to schema casing (uppercase).
+  const profile = reqStr('CAMUNDA_SDK_BACKPRESSURE_PROFILE');
   interface BpPreset {
     initialMax: number;
     soft: number;

--- a/src/runtime/unifiedConfiguration.ts
+++ b/src/runtime/unifiedConfiguration.ts
@@ -402,17 +402,23 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
   let envTyped: Record<string, any> = {};
   envTyped = createEnv(typedEnvSchema, { env: envInput });
 
-  // Build rawMap from typed values (string representation); fill in defaults for unset keys if defined
+  // Build rawMap from typed values (string representation); fill in schema defaults
+  // for unset keys. An explicitly empty / whitespace-only value is treated as unset, so
+  // defaulted keys always surface their schema default in rawMap (and therefore in
+  // `effective` / `__raw` and post-hydration inference) rather than an empty value.
   for (const k of allKeys()) {
     const entry = schemaEntry(k);
     const rawProvided = envInput[k];
+    const providedIsEmpty = rawProvided !== undefined && rawProvided.trim() === '';
     const val = envTyped[k];
-    if (val !== undefined && val !== null) {
+    const valIsEmptyString = typeof val === 'string' && val.trim() === '';
+    if (val !== undefined && val !== null && !valIsEmptyString) {
       rawMap[k] = typeof val === 'string' ? val : String(val);
-    } else if (rawProvided !== undefined) {
-      // A provided value failed to parse; parseErrors already collected.
+    } else if (rawProvided !== undefined && !providedIsEmpty && val === undefined) {
+      // A non-empty provided value failed to parse; parseErrors already collected.
       // Leave rawMap unset so conditional logic can still detect missing requiredWhen.
     } else if (entry.default !== undefined) {
+      // Unset or explicitly empty: fall back to the schema default.
       rawMap[k] = String(entry.default);
     }
   }

--- a/src/runtime/unifiedConfiguration.ts
+++ b/src/runtime/unifiedConfiguration.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { createEnv } from 'typed-env';
 import {
   allKeys,
+  defaultValue,
   type EnvOverrides,
   type EnvVarKey,
   isSecret,
@@ -431,18 +432,28 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
   if (
     !userSetStrategy &&
     rawMap.CAMUNDA_AUTH_STRATEGY === 'NONE' &&
-    rawMap.CAMUNDA_OAUTH_URL &&
-    rawMap.CAMUNDA_OAUTH_URL!.trim() !== '' &&
-    rawMap.CAMUNDA_CLIENT_ID &&
-    rawMap.CAMUNDA_CLIENT_ID!.trim() !== '' &&
-    rawMap.CAMUNDA_CLIENT_SECRET &&
-    rawMap.CAMUNDA_CLIENT_SECRET!.trim() !== ''
+    rawMap.CAMUNDA_OAUTH_URL?.trim() &&
+    rawMap.CAMUNDA_CLIENT_ID?.trim() &&
+    rawMap.CAMUNDA_CLIENT_SECRET?.trim()
   ) {
     rawMap.CAMUNDA_AUTH_STRATEGY = 'OAUTH';
   }
 
+  // Schema-backed accessors. `rawMap` is already fully defaulted from SCHEMA above,
+  // so these surface the effective value without re-declaring literals here — keeping
+  // configSchema.ts the single source of truth for defaults (#145).
+  const reqStr = (k: EnvVarKey): string => {
+    const v = rawMap[k];
+    if (v !== undefined) return v;
+    const d = defaultValue(k);
+    if (d !== undefined) return String(d);
+    throw new Error(`Internal configuration error: no value or schema default for ${k}`);
+  };
+  const reqInt = (k: EnvVarKey): number => parseInt(reqStr(k), 10);
+  const reqBool = (k: EnvVarKey): boolean => reqStr(k).trim().toLowerCase() === 'true';
+
   // Parse primitives (int, boolean, enum normalization) replicating original semantics
-  const authStrategyRaw = (rawMap.CAMUNDA_AUTH_STRATEGY || 'NONE').toString();
+  const authStrategyRaw = reqStr('CAMUNDA_AUTH_STRATEGY');
   const authStrategy = authStrategyRaw.trim().toUpperCase();
   if (!['NONE', 'OAUTH', 'BASIC'].includes(authStrategy)) {
     errors.push({
@@ -510,7 +521,7 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
   }
 
   // Parse validation config after potential errors so we gather full set
-  const validationRaw = rawMap.CAMUNDA_SDK_VALIDATION || 'req:none,res:none';
+  const validationRaw = reqStr('CAMUNDA_SDK_VALIDATION');
   const validation = parseValidation(validationRaw, errors);
 
   // If any errors, throw aggregated (sorted by key then code for determinism)
@@ -532,7 +543,7 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
   }
 
   // Normalize restAddress to ensure it ends with /v2 (idempotent)
-  let _restAddress = rawMap.CAMUNDA_REST_ADDRESS!;
+  let _restAddress = reqStr('CAMUNDA_REST_ADDRESS');
   if (_restAddress) {
     // Trim whitespace and trailing slashes first
     _restAddress = _restAddress.trim();
@@ -544,7 +555,7 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
     }
   }
   // Apply backpressure profile defaults if individual vars not explicitly provided.
-  const profile = (rawMap.CAMUNDA_SDK_BACKPRESSURE_PROFILE || 'BALANCED').toString().toUpperCase();
+  const profile = reqStr('CAMUNDA_SDK_BACKPRESSURE_PROFILE').toUpperCase();
   interface BpPreset {
     initialMax: number;
     soft: number;
@@ -558,20 +569,28 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
     healthyRecoveryMultiplier: number;
     unlimitedAfterHealthyMs: number;
   }
+  // BALANCED (and observe-only LEGACY) are exactly the SCHEMA defaults, derived here
+  // so the values are declared once in configSchema.ts (#145). CONSERVATIVE and
+  // AGGRESSIVE are intentional deltas and remain explicit.
+  const schemaBpDefaults: BpPreset = {
+    initialMax: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX')),
+    soft: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR')),
+    severe: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR')),
+    recoveryInterval: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS')),
+    recoveryStep: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP')),
+    quietMs: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_DECAY_QUIET_MS')),
+    floor: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_FLOOR')),
+    severeThreshold: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_SEVERE_THRESHOLD')),
+    maxWaiters: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_MAX_WAITERS')),
+    healthyRecoveryMultiplier: Number(
+      defaultValue('CAMUNDA_SDK_BACKPRESSURE_HEALTHY_RECOVERY_MULTIPLIER')
+    ),
+    unlimitedAfterHealthyMs: Number(
+      defaultValue('CAMUNDA_SDK_BACKPRESSURE_UNLIMITED_AFTER_HEALTHY_MS')
+    ),
+  };
   const PRESETS: Record<string, BpPreset> = {
-    BALANCED: {
-      initialMax: 16,
-      soft: 70,
-      severe: 50,
-      recoveryInterval: 1000,
-      recoveryStep: 1,
-      quietMs: 2000,
-      floor: 1,
-      severeThreshold: 3,
-      maxWaiters: 1000,
-      healthyRecoveryMultiplier: 150,
-      unlimitedAfterHealthyMs: 30_000,
-    },
+    BALANCED: schemaBpDefaults,
     CONSERVATIVE: {
       initialMax: 12,
       soft: 60,
@@ -598,20 +617,8 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
       healthyRecoveryMultiplier: 200,
       unlimitedAfterHealthyMs: 15_000,
     },
-    LEGACY: {
-      // observe-only: we still need plausible defaults if user overrides individual knobs
-      initialMax: 16,
-      soft: 70,
-      severe: 50,
-      recoveryInterval: 1000,
-      recoveryStep: 1,
-      quietMs: 2000,
-      floor: 1,
-      severeThreshold: 3,
-      maxWaiters: 1000,
-      healthyRecoveryMultiplier: 150,
-      unlimitedAfterHealthyMs: 30_000,
-    },
+    // observe-only: still needs plausible defaults if the user overrides individual knobs
+    LEGACY: schemaBpDefaults,
   };
   const preset = PRESETS[profile] || PRESETS.BALANCED;
   // Only override when user did NOT explicitly provide a value (env or override). We rely on the
@@ -633,61 +640,48 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
   ensure('CAMUNDA_SDK_BACKPRESSURE_UNLIMITED_AFTER_HEALTHY_MS', preset.unlimitedAfterHealthyMs);
   const config: CamundaConfig = {
     restAddress: _restAddress,
-    tokenAudience: rawMap.CAMUNDA_TOKEN_AUDIENCE!,
-    defaultTenantId: rawMap.CAMUNDA_DEFAULT_TENANT_ID || '<default>',
+    tokenAudience: reqStr('CAMUNDA_TOKEN_AUDIENCE'),
+    defaultTenantId: reqStr('CAMUNDA_DEFAULT_TENANT_ID'),
     httpRetry: {
-      maxAttempts: parseInt(rawMap.CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS || '3', 10),
-      baseDelayMs: parseInt(rawMap.CAMUNDA_SDK_HTTP_RETRY_BASE_DELAY_MS || '100', 10),
-      maxDelayMs: parseInt(rawMap.CAMUNDA_SDK_HTTP_RETRY_MAX_DELAY_MS || '2000', 10),
+      maxAttempts: reqInt('CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS'),
+      baseDelayMs: reqInt('CAMUNDA_SDK_HTTP_RETRY_BASE_DELAY_MS'),
+      maxDelayMs: reqInt('CAMUNDA_SDK_HTTP_RETRY_MAX_DELAY_MS'),
     },
     backpressure: {
       enabled: profile !== 'LEGACY',
       profile,
       observeOnly: profile === 'LEGACY',
-      initialMax: parseInt(rawMap.CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX || '16', 10),
+      initialMax: reqInt('CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX'),
       softFactor: Math.min(
         1,
-        Math.max(
-          0.01,
-          (parseInt(rawMap.CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR || '70', 10) || 70) / 100
-        )
+        Math.max(0.01, (reqInt('CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR') || 70) / 100)
       ),
       severeFactor: Math.min(
         1,
-        Math.max(
-          0.01,
-          (parseInt(rawMap.CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR || '50', 10) || 50) / 100
-        )
+        Math.max(0.01, (reqInt('CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR') || 50) / 100)
       ),
-      recoveryIntervalMs: parseInt(
-        rawMap.CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS || '1000',
-        10
-      ),
-      recoveryStep: parseInt(rawMap.CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP || '1', 10),
-      decayQuietMs: parseInt(rawMap.CAMUNDA_SDK_BACKPRESSURE_DECAY_QUIET_MS || '2000', 10),
-      floor: parseInt(rawMap.CAMUNDA_SDK_BACKPRESSURE_FLOOR || '1', 10),
-      severeThreshold: parseInt(rawMap.CAMUNDA_SDK_BACKPRESSURE_SEVERE_THRESHOLD || '3', 10),
-      maxWaiters: parseInt(rawMap.CAMUNDA_SDK_BACKPRESSURE_MAX_WAITERS || '1000', 10),
+      recoveryIntervalMs: reqInt('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS'),
+      recoveryStep: reqInt('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP'),
+      decayQuietMs: reqInt('CAMUNDA_SDK_BACKPRESSURE_DECAY_QUIET_MS'),
+      floor: reqInt('CAMUNDA_SDK_BACKPRESSURE_FLOOR'),
+      severeThreshold: reqInt('CAMUNDA_SDK_BACKPRESSURE_SEVERE_THRESHOLD'),
+      maxWaiters: reqInt('CAMUNDA_SDK_BACKPRESSURE_MAX_WAITERS'),
       healthyRecoveryMultiplier: Math.max(
         1,
-        (parseInt(rawMap.CAMUNDA_SDK_BACKPRESSURE_HEALTHY_RECOVERY_MULTIPLIER || '150', 10) ||
-          150) / 100
+        (reqInt('CAMUNDA_SDK_BACKPRESSURE_HEALTHY_RECOVERY_MULTIPLIER') || 150) / 100
       ),
-      unlimitedAfterHealthyMs: parseInt(
-        rawMap.CAMUNDA_SDK_BACKPRESSURE_UNLIMITED_AFTER_HEALTHY_MS || '30000',
-        10
-      ),
+      unlimitedAfterHealthyMs: reqInt('CAMUNDA_SDK_BACKPRESSURE_UNLIMITED_AFTER_HEALTHY_MS'),
     },
     oauth: {
       clientId: rawMap.CAMUNDA_CLIENT_ID?.trim() || undefined,
       clientSecret: rawMap.CAMUNDA_CLIENT_SECRET?.trim() || undefined,
-      oauthUrl: rawMap.CAMUNDA_OAUTH_URL!,
-      grantType: rawMap.CAMUNDA_OAUTH_GRANT_TYPE!,
+      oauthUrl: reqStr('CAMUNDA_OAUTH_URL'),
+      grantType: reqStr('CAMUNDA_OAUTH_GRANT_TYPE'),
       scope: rawMap.CAMUNDA_OAUTH_SCOPE?.trim() || undefined,
-      timeoutMs: parseInt(rawMap.CAMUNDA_OAUTH_TIMEOUT_MS!, 10),
+      timeoutMs: reqInt('CAMUNDA_OAUTH_TIMEOUT_MS'),
       retry: {
-        max: parseInt(rawMap.CAMUNDA_OAUTH_RETRY_MAX!, 10),
-        baseDelayMs: parseInt(rawMap.CAMUNDA_OAUTH_RETRY_BASE_DELAY_MS!, 10),
+        max: reqInt('CAMUNDA_OAUTH_RETRY_MAX'),
+        baseDelayMs: reqInt('CAMUNDA_OAUTH_RETRY_BASE_DELAY_MS'),
       },
       cacheDir: rawMap.CAMUNDA_OAUTH_CACHE_DIR?.trim() || undefined,
     },
@@ -702,9 +696,9 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
           : undefined,
     },
     validation: { req: validation.req, res: validation.res, raw: validation.raw },
-    logLevel: (rawMap.CAMUNDA_SDK_LOG_LEVEL as CamundaConfig['logLevel']) || 'info',
+    logLevel: reqStr('CAMUNDA_SDK_LOG_LEVEL') as CamundaConfig['logLevel'],
     eventual: {
-      pollDefaultMs: parseInt(rawMap.CAMUNDA_SDK_EVENTUAL_POLL_DEFAULT_MS || '500', 10),
+      pollDefaultMs: reqInt('CAMUNDA_SDK_EVENTUAL_POLL_DEFAULT_MS'),
     },
     mtls:
       rawMap.CAMUNDA_MTLS_CERT_PATH ||
@@ -725,12 +719,11 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
           }
         : undefined,
     telemetry: {
-      log: (rawMap.CAMUNDA_SDK_TELEMETRY_LOG || 'false').toString().toLowerCase() === 'true',
-      correlation:
-        (rawMap.CAMUNDA_SDK_TELEMETRY_CORRELATION || 'false').toString().toLowerCase() === 'true',
+      log: reqBool('CAMUNDA_SDK_TELEMETRY_LOG'),
+      correlation: reqBool('CAMUNDA_SDK_TELEMETRY_CORRELATION'),
     },
     supportLog: {
-      enabled: (rawMap.CAMUNDA_SUPPORT_LOG_ENABLED || 'false').toString().toLowerCase() === 'true',
+      enabled: reqBool('CAMUNDA_SUPPORT_LOG_ENABLED'),
       filePath:
         rawMap.CAMUNDA_SUPPORT_LOG_FILE_PATH ||
         (typeof process !== 'undefined' && typeof process.cwd === 'function'

--- a/src/runtime/unifiedConfiguration.ts
+++ b/src/runtime/unifiedConfiguration.ts
@@ -571,23 +571,20 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
   }
   // BALANCED (and observe-only LEGACY) are exactly the SCHEMA defaults, derived here
   // so the values are declared once in configSchema.ts (#145). CONSERVATIVE and
-  // AGGRESSIVE are intentional deltas and remain explicit.
+  // AGGRESSIVE are intentional deltas and remain explicit. reqInt() fails fast if a
+  // backpressure key ever loses its schema default (rather than silently yielding NaN).
   const schemaBpDefaults: BpPreset = {
-    initialMax: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX')),
-    soft: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR')),
-    severe: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR')),
-    recoveryInterval: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS')),
-    recoveryStep: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP')),
-    quietMs: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_DECAY_QUIET_MS')),
-    floor: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_FLOOR')),
-    severeThreshold: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_SEVERE_THRESHOLD')),
-    maxWaiters: Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_MAX_WAITERS')),
-    healthyRecoveryMultiplier: Number(
-      defaultValue('CAMUNDA_SDK_BACKPRESSURE_HEALTHY_RECOVERY_MULTIPLIER')
-    ),
-    unlimitedAfterHealthyMs: Number(
-      defaultValue('CAMUNDA_SDK_BACKPRESSURE_UNLIMITED_AFTER_HEALTHY_MS')
-    ),
+    initialMax: reqInt('CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX'),
+    soft: reqInt('CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR'),
+    severe: reqInt('CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR'),
+    recoveryInterval: reqInt('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS'),
+    recoveryStep: reqInt('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP'),
+    quietMs: reqInt('CAMUNDA_SDK_BACKPRESSURE_DECAY_QUIET_MS'),
+    floor: reqInt('CAMUNDA_SDK_BACKPRESSURE_FLOOR'),
+    severeThreshold: reqInt('CAMUNDA_SDK_BACKPRESSURE_SEVERE_THRESHOLD'),
+    maxWaiters: reqInt('CAMUNDA_SDK_BACKPRESSURE_MAX_WAITERS'),
+    healthyRecoveryMultiplier: reqInt('CAMUNDA_SDK_BACKPRESSURE_HEALTHY_RECOVERY_MULTIPLIER'),
+    unlimitedAfterHealthyMs: reqInt('CAMUNDA_SDK_BACKPRESSURE_UNLIMITED_AFTER_HEALTHY_MS'),
   };
   const PRESETS: Record<string, BpPreset> = {
     BALANCED: schemaBpDefaults,

--- a/src/runtime/unifiedConfiguration.ts
+++ b/src/runtime/unifiedConfiguration.ts
@@ -436,9 +436,13 @@ export function hydrateConfig(options: HydrateOptions = {}): HydratedConfigurati
   // configSchema.ts the single source of truth for defaults (#145).
   const reqStr = (k: EnvVarKey): string => {
     const v = rawMap[k];
-    if (v !== undefined) return v;
+    // Treat an explicitly empty / whitespace-only value as unset so it falls back to
+    // the schema default (preserves the pre-refactor `|| 'default'` semantics — e.g.
+    // an empty CAMUNDA_DEFAULT_TENANT_ID must not become an empty tenant id).
+    if (v !== undefined && v.trim() !== '') return v;
     const d = defaultValue(k);
     if (d !== undefined) return String(d);
+    if (v !== undefined) return v;
     throw new Error(`Internal configuration error: no value or schema default for ${k}`);
   };
   const reqInt = (k: EnvVarKey): number => {

--- a/tests/config-hydration.test.ts
+++ b/tests/config-hydration.test.ts
@@ -61,6 +61,12 @@ describe('unified configuration hydration', () => {
     expect(config.restAddress).toBe('https://cluster.alias.example/v2');
   });
 
+  it('falls back to the schema default when a defaulted string var is empty', () => {
+    // An explicitly empty env var must not become an empty effective value.
+    const { config } = hydrateConfig({ env: { CAMUNDA_DEFAULT_TENANT_ID: '' } });
+    expect(config.defaultTenantId).toBe('<default>');
+  });
+
   it('infers OAUTH auth strategy when CAMUNDA_OAUTH_URL provided and strategy missing', () => {
     const { config } = hydrateConfig({
       env: {

--- a/tests/config-hydration.test.ts
+++ b/tests/config-hydration.test.ts
@@ -62,9 +62,12 @@ describe('unified configuration hydration', () => {
   });
 
   it('falls back to the schema default when a defaulted string var is empty', () => {
-    // An explicitly empty env var must not become an empty effective value.
-    const { config } = hydrateConfig({ env: { CAMUNDA_DEFAULT_TENANT_ID: '' } });
+    // An explicitly empty env var must not become an empty effective value, and the
+    // schema default must be applied at the rawMap stage so effective / __raw reflect it.
+    const { config, effective } = hydrateConfig({ env: { CAMUNDA_DEFAULT_TENANT_ID: '' } });
     expect(config.defaultTenantId).toBe('<default>');
+    expect(config.__raw.CAMUNDA_DEFAULT_TENANT_ID).toBe('<default>');
+    expect(effective.CAMUNDA_DEFAULT_TENANT_ID).toBe('<default>');
   });
 
   it('infers OAUTH auth strategy when CAMUNDA_OAUTH_URL provided and strategy missing', () => {

--- a/tests/config-single-source.guard.test.ts
+++ b/tests/config-single-source.guard.test.ts
@@ -104,7 +104,12 @@ describe('configuration single source of truth (#145)', () => {
       fileURLToPath(new URL('../src/runtime/unifiedConfiguration.ts', import.meta.url)),
       'utf8'
     );
-    const missing = allKeys().filter((k) => !ALLOW_UNREFERENCED.has(k) && !src.includes(k));
+    const missing = allKeys().filter((k) => {
+      if (ALLOW_UNREFERENCED.has(k)) return false;
+      // Require a code-like reference — a quoted string literal (e.g. reqStr('K'))
+      // or a property access (e.g. rawMap.K) — not an incidental mention in a comment.
+      return !new RegExp(`['"]${k}['"]|\\.${k}\\b`).test(src);
+    });
     expect(
       missing,
       `SCHEMA keys never referenced in unifiedConfiguration.ts (wire them into CamundaConfig, or allow-list with a reason): ${missing.join(', ')}`

--- a/tests/config-single-source.guard.test.ts
+++ b/tests/config-single-source.guard.test.ts
@@ -70,8 +70,10 @@ describe('configuration single source of truth (#145)', () => {
       'utf8'
     );
 
-    // `rawMap.CAMUNDA_X!` — non-null assertion on a rawMap read.
-    const nonNull = src.match(/rawMap\.[A-Z_]+\s*!/g) ?? [];
+    // `rawMap.CAMUNDA_X!` — non-null assertion on a rawMap read. The negative
+    // lookahead `(?!=)` excludes comparison operators (`!=` / `!==`) so a future
+    // `rawMap.KEY !== ...` is not a false positive.
+    const nonNull = src.match(/rawMap\.[A-Z_]+!(?!=)/g) ?? [];
     // `rawMap.CAMUNDA_X || 'literal'` or `|| 3` — inline literal default fallback.
     // `|| undefined` is allowed (genuinely optional field, not a duplicated default).
     const inlineDefault = src.match(/rawMap\.[A-Z_]+(?:\?\.\w+\(\))?\s*\|\|\s*['"\d]/g) ?? [];

--- a/tests/config-single-source.guard.test.ts
+++ b/tests/config-single-source.guard.test.ts
@@ -1,0 +1,104 @@
+// Guard tests for issue #145: SCHEMA (configSchema.ts) must remain the single
+// source of truth for configuration defaults. These lock in the behaviour that
+// the hydration pipeline surfaces schema defaults without re-declaring literals,
+// and prevent reintroduction of inline `|| 'literal'` fallbacks / `rawMap.X!`
+// non-null assertions in the hydration code.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { allKeys, defaultValue } from '../src/runtime/configSchema';
+import { hydrateConfig } from '../src/runtime/unifiedConfiguration';
+
+describe('configuration single source of truth (#145)', () => {
+  // Behaviour guard (green/green): every key that declares a schema default must
+  // surface that exact default through hydration when nothing is provided.
+  it('surfaces every schema default through hydration (class-scoped)', () => {
+    const { config } = hydrateConfig({ env: {} });
+    const defaulted = allKeys().filter((k) => defaultValue(k) !== undefined);
+    // Sanity: there is a meaningful number of defaulted keys to guard.
+    expect(defaulted.length).toBeGreaterThan(15);
+    for (const k of defaulted) {
+      expect(config.__raw[k], `__raw[${k}] should equal schema default`).toBe(
+        String(defaultValue(k))
+      );
+    }
+  });
+
+  // Backpressure single-source guard (green/green): the BALANCED profile (and the
+  // observe-only LEGACY profile) must be exactly the schema defaults, so the
+  // presets can be derived from SCHEMA rather than restated as literals.
+  it('BALANCED backpressure profile equals schema defaults (effective config)', () => {
+    const { config } = hydrateConfig({ env: { CAMUNDA_SDK_BACKPRESSURE_PROFILE: 'BALANCED' } });
+    const bp = config.backpressure;
+    expect(bp.initialMax).toBe(Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX')));
+    expect(bp.softFactor).toBe(Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_SOFT_FACTOR')) / 100);
+    expect(bp.severeFactor).toBe(
+      Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_SEVERE_FACTOR')) / 100
+    );
+    expect(bp.recoveryIntervalMs).toBe(
+      Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_INTERVAL_MS'))
+    );
+    expect(bp.recoveryStep).toBe(Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_RECOVERY_STEP')));
+    expect(bp.decayQuietMs).toBe(Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_DECAY_QUIET_MS')));
+    expect(bp.floor).toBe(Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_FLOOR')));
+    expect(bp.severeThreshold).toBe(
+      Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_SEVERE_THRESHOLD'))
+    );
+    expect(bp.maxWaiters).toBe(Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_MAX_WAITERS')));
+    expect(bp.healthyRecoveryMultiplier).toBe(
+      Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_HEALTHY_RECOVERY_MULTIPLIER')) / 100
+    );
+    expect(bp.unlimitedAfterHealthyMs).toBe(
+      Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_UNLIMITED_AFTER_HEALTHY_MS'))
+    );
+  });
+
+  it('LEGACY backpressure profile knobs equal schema defaults (effective config)', () => {
+    const { config } = hydrateConfig({ env: { CAMUNDA_SDK_BACKPRESSURE_PROFILE: 'LEGACY' } });
+    const bp = config.backpressure;
+    expect(bp.observeOnly).toBe(true);
+    expect(bp.initialMax).toBe(Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_INITIAL_MAX')));
+    expect(bp.maxWaiters).toBe(Number(defaultValue('CAMUNDA_SDK_BACKPRESSURE_MAX_WAITERS')));
+  });
+
+  // Anti-pattern lint guard (red until the refactor lands): the hydration source
+  // must not re-declare schema defaults as inline `|| 'literal'` fallbacks, nor
+  // assert non-null on rawMap reads (`rawMap.X!`). Both hide divergence from SCHEMA.
+  it('hydration source contains no inline default fallbacks or rawMap non-null assertions', () => {
+    const src = readFileSync(
+      fileURLToPath(new URL('../src/runtime/unifiedConfiguration.ts', import.meta.url)),
+      'utf8'
+    );
+
+    // `rawMap.CAMUNDA_X!` — non-null assertion on a rawMap read.
+    const nonNull = src.match(/rawMap\.[A-Z_]+\s*!/g) ?? [];
+    // `rawMap.CAMUNDA_X || 'literal'` or `|| 3` — inline literal default fallback.
+    // `|| undefined` is allowed (genuinely optional field, not a duplicated default).
+    const inlineDefault = src.match(/rawMap\.[A-Z_]+(?:\?\.\w+\(\))?\s*\|\|\s*['"\d]/g) ?? [];
+
+    expect(nonNull, `Found rawMap non-null assertions: ${nonNull.join(', ')}`).toEqual([]);
+    expect(
+      inlineDefault,
+      `Found inline default fallbacks duplicating SCHEMA: ${inlineDefault.join(', ')}`
+    ).toEqual([]);
+  });
+
+  // Completeness guard: every key declared in SCHEMA must be explicitly handled in
+  // the hydrator. This catches the "added a key to SCHEMA but forgot to wire it into
+  // CamundaConfig" mistake — the structural mapping is still hand-written, so a new
+  // key is otherwise silently absent from the effective config. Keys that are
+  // intentionally consumed only via generic `allKeys()` iteration (never named) may
+  // be added to ALLOW_UNREFERENCED with a justification.
+  it('every SCHEMA key is referenced by name in the hydration source', () => {
+    const ALLOW_UNREFERENCED = new Set<string>();
+    const src = readFileSync(
+      fileURLToPath(new URL('../src/runtime/unifiedConfiguration.ts', import.meta.url)),
+      'utf8'
+    );
+    const missing = allKeys().filter((k) => !ALLOW_UNREFERENCED.has(k) && !src.includes(k));
+    expect(
+      missing,
+      `SCHEMA keys never referenced in unifiedConfiguration.ts (wire them into CamundaConfig, or allow-list with a reason): ${missing.join(', ')}`
+    ).toEqual([]);
+  });
+});

--- a/tests/config-single-source.guard.test.ts
+++ b/tests/config-single-source.guard.test.ts
@@ -77,11 +77,18 @@ describe('configuration single source of truth (#145)', () => {
     // `rawMap.CAMUNDA_X || 'literal'` or `|| 3` — inline literal default fallback.
     // `|| undefined` is allowed (genuinely optional field, not a duplicated default).
     const inlineDefault = src.match(/rawMap\.[A-Z_]+(?:\?\.\w+\(\))?\s*\|\|\s*['"\d]/g) ?? [];
+    // `reqInt(...) || 70` etc. — an accessor result with an inline literal fallback,
+    // which both duplicates the SCHEMA default and masks a NaN from a failed parse.
+    const accessorDefault = src.match(/req(?:Int|Str|Bool)\([^)]*\)\s*\|\|\s*['"\d]/g) ?? [];
 
     expect(nonNull, `Found rawMap non-null assertions: ${nonNull.join(', ')}`).toEqual([]);
     expect(
       inlineDefault,
       `Found inline default fallbacks duplicating SCHEMA: ${inlineDefault.join(', ')}`
+    ).toEqual([]);
+    expect(
+      accessorDefault,
+      `Found accessor default fallbacks duplicating SCHEMA: ${accessorDefault.join(', ')}`
     ).toEqual([]);
   });
 


### PR DESCRIPTION
## What

Hardens the configuration layer so `configSchema.ts` (`SCHEMA`) is the single source of truth for configuration **defaults**, installs guard tests to keep it that way, and works through the rest of jwulf's #145 hydration audit. Closes #145.

> **Scope note:** this PR started as a focused hydration-defaults refactor and grew, in response to review + the #145 audit, to cover the remaining audit items — including a small amount of worker-runtime code (`jobWorker.ts` / `threadedJobWorker.ts`). Happy to split the worker type-split into its own PR if preferred.

## Core change — schema is the single source of truth for defaults

Previously `hydrateConfig()` re-declared schema defaults in three places:

- inline `parseInt(rawMap.X || '3', 10)` / `rawMap.X || 'literal'` fallbacks in the `CamundaConfig` construction,
- `rawMap.X!` non-null assertions (load-bearing only because TS couldn't see the schema guarantee),
- the backpressure `BALANCED` and `LEGACY` presets, which restated 11 schema defaults as literals.

`rawMap` is already fully defaulted from `SCHEMA`, so those literals were redundant duplication that could silently drift.

- Added schema-backed accessors (`reqStr` / `reqInt` / `reqBool`) that fall back to `defaultValue(key)` from `SCHEMA`.
- Replaced all inline literal fallbacks and every `rawMap.X!` (including the OAuth-inference safeguards) with those accessors.
- Derived the `BALANCED` and `LEGACY` backpressure presets from schema defaults; `CONSERVATIVE` / `AGGRESSIVE` stay explicit intentional deltas.

## Remaining #145 audit items addressed

Mapping to jwulf's audit categories:

- **(1) Redundant double-defaulting** — removed (see core change above).
- **(3) Non-null assertions on defaulted keys** — removed.
- **(4) Undocumented `ZEEBE_REST_ADDRESS` alias** — now declared in `SCHEMA` (`CAMUNDA_REST_ADDRESS.aliases`) and documented; the hydration fallback is driven generically from the schema instead of being hardcoded.
- **(5) Redundant enum case normalization** — dropped the extra `.toUpperCase()` on `CAMUNDA_SDK_BACKPRESSURE_PROFILE` and `CAMUNDA_AUTH_STRATEGY` (the enum parser already canonicalizes).
- **(2) Boolean triple-conversion** — `reqBool` reads the already-typed value from typed-env instead of re-parsing the stringified `rawMap` on the value path.
- **(6) Auth-strategy triple-inference** — consolidated into a single post-hydration transform (removed the duplicate pre-typed-env pass over `envInput`).
- **Structural input/resolved type split** — added `ResolvedJobWorkerConfig` / `ResolvedThreadedJobWorkerConfig` where defaulted fields are required, built via the constructor spread. The compiler now enforces defaults, so the `maxParallelJobs!` / `jobTimeoutMs!` / `pollIntervalMs!` assertions are gone; adding a new defaulted field without a default is now a compile error. The type-honesty backstop test (`tests/worker-type-honesty.test.ts`) already existed and stays green.

Not taken: jwulf's early "make *all* env vars declare a default (allowing `null`)" idea — superseded by the type-split he later proposed, which avoids forcing meaningless `default: null` on genuinely-optional keys.

No change to public types (`EnvOverrides`, `CamundaConfig`) or the env-var precedence order (`explicit > env > default`) — behaviour-preserving throughout.

## Guard tests (`tests/config-single-source.guard.test.ts`)

- **Behaviour:** every schema-defaulted key surfaces its exact default through hydration (class-scoped).
- **Backpressure:** `BALANCED` (and observe-only `LEGACY`) effective config equals the schema defaults.
- **Anti-pattern lint:** bans re-introduction of inline `|| 'literal'` fallbacks and `rawMap.X!` (the assertion regex uses a negative lookahead so `!=` / `!==` are not false positives).
- **Completeness:** every `SCHEMA` key is referenced in the hydrator, catching "added a key but forgot to wire it into `CamundaConfig`".

Developed green/green: guards written first and shown to pass on the pre-refactor code (anti-pattern lint red until the refactor landed), then green after.

## Out of scope

- Migrating to a fully declarative key→config-path table (the structural mapping is still hand-written). The active default duplication that #145 flagged is closed; the completeness guard covers the "forgot to wire a key" gap.

## Validation

- Config + worker suites green (`config-hydration`, `configuration`, `config-normalization`, `config.auth-strategy-inference`, `worker-defaults`, `worker-type-honesty`, and the new guard file).
- No type errors; Biome clean.

> Note: pre-existing `tests/threaded-job-worker.test.ts` timeouts on a stale local `dist/` are unrelated to this change (confirmed identical on baseline) and clear on a fresh build; CI builds before testing.
