### PR TITLE
docs: add restore example coverage

### DIFF
--- a/examples/client.ts
+++ b/examples/client.ts
@@ -85,6 +85,24 @@ async function changeClusterModeExample() {
 }
 //#endregion ChangeClusterMode
 
+//#region Restore
+async function restoreExample() {
+  const camunda = createCamundaClient();
+
+  // The cluster must be in recovery mode before a restore is accepted. Provide
+  // either a list of backup IDs (one per partition) or a time range (`from`/`to`)
+  // that selects the backups to restore, but not both.
+  const change = await camunda.restore({
+    backupIds: [100, 101],
+  });
+
+  console.log(`Cluster change ${change.changeId}:`);
+  for (const op of change.plannedChanges) {
+    console.log(`  ${op.operation}${op.mode ? ` -> ${op.mode}` : ''}`);
+  }
+}
+//#endregion Restore
+
 //#region ResultClient
 async function resultClientExample() {
   const camunda = createCamundaResultClient({

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -55,6 +55,13 @@
       "label": "Change cluster mode"
     }
   ],
+  "restore": [
+    {
+      "file": "client.ts",
+      "region": "Restore",
+      "label": "Restore from a backup"
+    }
+  ],
   "createProcessInstance": [
     {
       "file": "process-instance.ts",


### PR DESCRIPTION
## Description

Adds example coverage for the `restore` operation (`POST /restore`, tag `Recovery`, added in 8.10), closing the coverage gap reported in #338.

- Add a `Restore` region example to `examples/client.ts` (Recovery domain, alongside `ChangeClusterMode`), calling `camunda.restore({ backupIds: [...] })` and noting the `from`/`to` time-range alternative.
- Add the `restore` entry to `examples/operation-map.json`.

Following the same convention as the merged `changeClusterMode` example PR, this touches only the two hand-written example files. Generated code (`src/gen`, `src/facade`), the bundled spec, and test scaffolds are regenerated fresh by CI and are intentionally not committed here.

## Verification

Validated locally by regenerating the SDK from the latest upstream spec (not committed):
- `npx tsc -p examples/tsconfig.json` — example type-checks against the generated `restore(body: RestoreRequest)` method
- `node scripts/check-example-coverage.cjs` — 100% (197/197), integrity check passes

Closes #338
