### PR TITLE
docs: add searchProcessDefinitionVariableNames example coverage

### DIFF
--- a/examples/extended-operations.ts
+++ b/examples/extended-operations.ts
@@ -188,6 +188,21 @@ async function searchProcessDefinitionsExample() {
 }
 //#endregion SearchProcessDefinitions
 
+//#region SearchProcessDefinitionVariableNames
+async function searchProcessDefinitionVariableNamesExample(processDefinitionKey: ProcessDefinitionKey) {
+  const camunda = createCamundaClient();
+
+  const result = await camunda.searchProcessDefinitionVariableNames(
+    { processDefinitionKey },
+    { consistency: { waitUpToMs: 5000 } }
+  );
+
+  for (const variable of result.items ?? []) {
+    console.log(`Variable name: ${variable.name}`);
+  }
+}
+//#endregion SearchProcessDefinitionVariableNames
+
 //#region GetProcessDefinitionStatistics
 async function getProcessDefinitionStatisticsExample(processDefinitionKey: ProcessDefinitionKey) {
   const camunda = createCamundaClient();

--- a/examples/extended-operations.ts
+++ b/examples/extended-operations.ts
@@ -189,7 +189,9 @@ async function searchProcessDefinitionsExample() {
 //#endregion SearchProcessDefinitions
 
 //#region SearchProcessDefinitionVariableNames
-async function searchProcessDefinitionVariableNamesExample(processDefinitionKey: ProcessDefinitionKey) {
+async function searchProcessDefinitionVariableNamesExample(
+  processDefinitionKey: ProcessDefinitionKey
+) {
   const camunda = createCamundaClient();
 
   const result = await camunda.searchProcessDefinitionVariableNames(
@@ -464,6 +466,7 @@ void resolveProcessInstanceIncidentsExample;
 void getProcessDefinitionExample;
 void getProcessDefinitionXmlExample;
 void searchProcessDefinitionsExample;
+void searchProcessDefinitionVariableNamesExample;
 void getProcessDefinitionStatisticsExample;
 void getProcessDefinitionInstanceStatisticsExample;
 void getProcessDefinitionInstanceVersionStatisticsExample;

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -877,6 +877,13 @@
       "label": "Search process definitions"
     }
   ],
+  "searchProcessDefinitionVariableNames": [
+    {
+      "file": "extended-operations.ts",
+      "region": "SearchProcessDefinitionVariableNames",
+      "label": "Search process definition variable names"
+    }
+  ],
   "getProcessDefinitionStatistics": [
     {
       "file": "extended-operations.ts",


### PR DESCRIPTION
## Description

Adds example coverage for the `searchProcessDefinitionVariableNames` operation (`POST /process-definitions/{processDefinitionKey}/variable-names/search`, tag `Process definition`, added in 8.10), closing the coverage gap reported in #348.

- Add a `SearchProcessDefinitionVariableNames` region example to `examples/extended-operations.ts` (alongside `SearchProcessDefinitions`), calling `camunda.searchProcessDefinitionVariableNames({ processDefinitionKey }, { consistency: {...} })` and printing each `variable.name`. The endpoint is eventually consistent, so the mandatory `consistency` option is included, matching the sibling examples.
- Add the `searchProcessDefinitionVariableNames` entry to `examples/operation-map.json`.

Following the same convention as the merged `changeClusterMode`/`restore` example PRs, this touches only the two hand-written example files. Generated code (`src/gen`, `src/facade`), the bundled spec, and test scaffolds are regenerated fresh by CI and are intentionally not committed here.

## Verification

Validated locally by regenerating the SDK from the latest upstream spec (not committed):
- `tsc -p examples/tsconfig.json` — example type-checks against the generated method
- `check-example-coverage.cjs` — 100% (198/198), integrity check passes

Closes #348
