### PR TITLE
docs: add examples for process instance suspend/resume/business-id operations

### DIFF
--- a/examples/batch-operation.ts
+++ b/examples/batch-operation.ts
@@ -207,6 +207,38 @@ async function updateJobsBatchOperationExample() {
 }
 //#endregion UpdateJobsBatchOperation
 
+//#region SuspendProcessInstancesBatchOperation
+async function suspendProcessInstancesBatchOperationExample(
+  processDefinitionKey: ProcessDefinitionKey
+) {
+  const camunda = createCamundaClient();
+
+  const result = await camunda.suspendProcessInstancesBatchOperation({
+    filter: {
+      processDefinitionKey,
+    },
+  });
+
+  console.log(`Batch operation key: ${result.batchOperationKey}`);
+}
+//#endregion SuspendProcessInstancesBatchOperation
+
+//#region ResumeProcessInstancesBatchOperation
+async function resumeProcessInstancesBatchOperationExample(
+  processDefinitionKey: ProcessDefinitionKey
+) {
+  const camunda = createCamundaClient();
+
+  const result = await camunda.resumeProcessInstancesBatchOperation({
+    filter: {
+      processDefinitionKey,
+    },
+  });
+
+  console.log(`Batch operation key: ${result.batchOperationKey}`);
+}
+//#endregion ResumeProcessInstancesBatchOperation
+
 // Suppress "declared but never read"
 void getBatchOperationExample;
 void searchBatchOperationsExample;
@@ -221,3 +253,5 @@ void modifyProcessInstancesBatchOperationExample;
 void resolveIncidentsBatchOperationExample;
 void deleteDecisionInstancesBatchOperationExample;
 void updateJobsBatchOperationExample;
+void suspendProcessInstancesBatchOperationExample;
+void resumeProcessInstancesBatchOperationExample;

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -95,6 +95,27 @@
       "label": "Search process instances"
     }
   ],
+  "suspendProcessInstance": [
+    {
+      "file": "process-instance.ts",
+      "region": "SuspendProcessInstance",
+      "label": "Suspend a process instance"
+    }
+  ],
+  "resumeProcessInstance": [
+    {
+      "file": "process-instance.ts",
+      "region": "ResumeProcessInstance",
+      "label": "Resume a process instance"
+    }
+  ],
+  "assignProcessInstanceBusinessId": [
+    {
+      "file": "process-instance.ts",
+      "region": "AssignProcessInstanceBusinessId",
+      "label": "Assign a business id to a process instance"
+    }
+  ],
   "createDeployment": [
     {
       "file": "deployment.ts",
@@ -791,6 +812,20 @@
       "file": "batch-operation.ts",
       "region": "UpdateJobsBatchOperation",
       "label": "Update jobs in batch"
+    }
+  ],
+  "suspendProcessInstancesBatchOperation": [
+    {
+      "file": "batch-operation.ts",
+      "region": "SuspendProcessInstancesBatchOperation",
+      "label": "Suspend process instances in batch"
+    }
+  ],
+  "resumeProcessInstancesBatchOperation": [
+    {
+      "file": "batch-operation.ts",
+      "region": "ResumeProcessInstancesBatchOperation",
+      "label": "Resume process instances in batch"
     }
   ],
   "deleteProcessInstance": [

--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -113,7 +113,7 @@
     {
       "file": "process-instance.ts",
       "region": "AssignProcessInstanceBusinessId",
-      "label": "Assign a business id to a process instance"
+      "label": "Assign a business ID to a process instance"
     }
   ],
   "createDeployment": [

--- a/examples/process-instance.ts
+++ b/examples/process-instance.ts
@@ -2,6 +2,7 @@
 // These examples are type-checked during build to guard against API regressions.
 
 import {
+  type BusinessId,
   createCamundaClient,
   type ProcessDefinitionId,
   type ProcessDefinitionKey,
@@ -91,9 +92,42 @@ async function searchProcessInstancesExample(processDefinitionId: ProcessDefinit
 }
 //#endregion SearchProcessInstances
 
+//#region SuspendProcessInstance
+async function suspendProcessInstanceExample(processInstanceKey: ProcessInstanceKey) {
+  const camunda = createCamundaClient();
+
+  await camunda.suspendProcessInstance({ processInstanceKey });
+}
+//#endregion SuspendProcessInstance
+
+//#region ResumeProcessInstance
+async function resumeProcessInstanceExample(processInstanceKey: ProcessInstanceKey) {
+  const camunda = createCamundaClient();
+
+  await camunda.resumeProcessInstance({ processInstanceKey });
+}
+//#endregion ResumeProcessInstance
+
+//#region AssignProcessInstanceBusinessId
+async function assignProcessInstanceBusinessIdExample(
+  processInstanceKey: ProcessInstanceKey,
+  businessId: BusinessId
+) {
+  const camunda = createCamundaClient();
+
+  await camunda.assignProcessInstanceBusinessId({
+    processInstanceKey,
+    businessId,
+  });
+}
+//#endregion AssignProcessInstanceBusinessId
+
 // Suppress "declared but never read"
 void createProcessInstanceByIdExample;
 void createProcessInstanceByKeyExample;
 void cancelProcessInstanceExample;
 void getProcessInstanceExample;
 void searchProcessInstancesExample;
+void suspendProcessInstanceExample;
+void resumeProcessInstanceExample;
+void assignProcessInstanceBusinessIdExample;


### PR DESCRIPTION
## Description

Adds compilable usage examples for five process instance operations introduced in Camunda 8.10 (tag `Process instance`) that were missing example coverage. Each new example is region-tagged and wired into `examples/operation-map.json` so it is injected as an `@example` in the generated API docs and IntelliSense.

| Operation | Endpoint | Example file / region |
| --- | --- | --- |
| `suspendProcessInstance` | `POST /process-instances/{processInstanceKey}/suspension` | `process-instance.ts` → `SuspendProcessInstance` |
| `resumeProcessInstance` | `POST /process-instances/{processInstanceKey}/resumption` | `process-instance.ts` → `ResumeProcessInstance` |
| `assignProcessInstanceBusinessId` | `POST /process-instances/{processInstanceKey}/business-id-assignment` | `process-instance.ts` → `AssignProcessInstanceBusinessId` |
| `suspendProcessInstancesBatchOperation` | `POST /process-instances/suspension` | `batch-operation.ts` → `SuspendProcessInstancesBatchOperation` |
| `resumeProcessInstancesBatchOperation` | `POST /process-instances/resumption` | `batch-operation.ts` → `ResumeProcessInstancesBatchOperation` |

Only the two example files and `operation-map.json` are committed; `src/gen/` is regenerated by CI.

## Validation

- `npx tsc -p examples/tsconfig.json` — clean
- `node scripts/check-example-coverage.cjs` — 100% (203/203, 0 missing)
- `npx biome check` on the edited files — clean

Closes #351
