### PR TITLE
ci: add lint and typecheck gates, fix drift artifact, enable renovate CVE alerts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,5 +31,6 @@
       "automerge": true
     }
   ],
-  "vulnerabilityAlerts": { "enabled": false }
+  "vulnerabilityAlerts": { "enabled": true },
+  "osvVulnerabilityAlerts": true
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: 22.x
           cache: 'npm'
-          cache-dependency-path: package.json
+          cache-dependency-path: package-lock.json
       - name: Install deps
         run: npm ci
       - name: Generate
@@ -60,7 +60,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'
-          cache-dependency-path: package.json
+          cache-dependency-path: package-lock.json
       - name: Install deps
         run: npm ci
       - name: Generate & Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,28 @@ jobs:
     if: github.event_name == 'pull_request'
     uses: camunda/sdk-infra/.github/workflows/sdk-breaking-change-guard.yml@v1
 
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: 'npm'
+          cache-dependency-path: package.json
+      - name: Install deps
+        run: npm ci
+      - name: Generate
+        run: npm run generate
+      - name: Lint (Biome)
+        run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -54,7 +76,7 @@ jobs:
             echo 'drift=true' >> $GITHUB_OUTPUT
             echo 'Generation produced changes (reporting only).' >&2
             git diff --name-only | sed 's/^/CHANGED: /'
-            git diff > _gen-drift.patch || true
+            git diff > _generation-drift.patch || true
           else
             echo 'drift=false' >> $GITHUB_OUTPUT
           fi

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:dist": "npm run build --silent && node tests/dist-usage.smoke.mjs",
     "lint": "biome lint .",
     "lint:fix": "biome check . --write",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "format": "biome format . --write",
     "format:check": "biome check .",
     "release": "semantic-release",

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "scripts"],
+  "exclude": ["dist", "node_modules", "src/template"]
+}


### PR DESCRIPTION
## Summary

Turns several of the repo's stated norms ("warnings are fatal", "always green", derive-don't-duplicate) into actual CI signals, and fixes a broken drift artifact. Motivated by a repository audit that found strong written policy but a soft enforcement layer.

## Changes

- **New `quality` CI job** (runs in parallel with the test matrix): `biome lint` + a standalone `tsc --noEmit` typecheck. Independent, fast, and intended to be made merge-blocking via the `Protect main` ruleset.
- **Standalone typecheck**: adds `tsconfig.typecheck.json` and a `typecheck` npm script. Bare `tsc --noEmit` over `src` fails on the spliced `src/template/**` placeholders and the `.ts` import extension in `threadWorkerEntry.ts`, so the config excludes the template dir and enables `allowImportingTsExtensions`. Previously, typechecking only rode on `tsup --dts` for the 3 published entrypoints.
- **Fix generation-drift artifact**: the drift step wrote `_gen-drift.patch` but uploaded `_generation-drift.patch`, so the artifact was always empty. Aligned both to `_generation-drift.patch`.
- **Enable Renovate CVE handling**: `vulnerabilityAlerts` + `osvVulnerabilityAlerts` (were disabled). The default branch currently has 33 open Dependabot alerts.

## Deliberately NOT included

- **`biome check .` as the lint gate** — it reports 384 errors because `check` runs the organize-imports assist that the build (`biome format`) never applies. The gate uses `biome lint .` (0 errors) instead.
- **Elevating `warn` rules to `error` / banning `any`, `!`, `@ts-ignore`** — the current warnings are region-tagged example functions defined for README snippets but never called, and there are ~391 `any` sites in hand-written `src`. This needs an `examples/`+`scripts/` override and an incremental burn-down; deferred.
- **Making generation-drift merge-blocking** — the spec is bundled from upstream `main` at build time, so drift can be caused by upstream movement unrelated to the PR. Should be pinned to a `SPEC_REF` before gating.

## Follow-up (requires repo-admin permissions)

Add a `required_status_checks` rule to the `Protect main` ruleset pinning `quality` and the `test (…)` matrix legs. That single config change converts the existing CI suite from advisory to merge-blocking.

## Verification

- `npm run typecheck` → exit 0
- `npm run lint` → 0 errors
