### PR TITLE
docs: add resolveSecrets example

### DIFF
--- a/examples/operation-map.json
+++ b/examples/operation-map.json
@@ -1429,5 +1429,12 @@
       "region": "SearchUserTaskEffectiveVariables",
       "label": "Search user task effective variables"
     }
+  ],
+  "resolveSecrets": [
+    {
+      "file": "secret.ts",
+      "region": "ResolveSecrets",
+      "label": "Resolve secrets"
+    }
   ]
 }

--- a/examples/secret.ts
+++ b/examples/secret.ts
@@ -1,0 +1,33 @@
+// Compilable usage examples for secret operations.
+// These examples are type-checked during build to guard against API regressions.
+
+import { createCamundaClient } from '@camunda8/orchestration-cluster-api';
+
+//#region ResolveSecrets
+async function resolveSecretsExample() {
+  const camunda = createCamundaClient();
+
+  const result = await camunda.resolveSecrets({
+    references: ['camunda.secrets.myApiToken', 'camunda.secrets.dbPassword'],
+  });
+
+  // Successfully resolved references are returned in `resolved`; references that
+  // could not be resolved are returned in `errors`, each with a typed error code.
+  // Never log a resolved value — it holds secret material. Pass it straight to the
+  // consumer that needs it (HTTP client, DB driver, ...) instead.
+  for (const resolved of result.resolved) {
+    console.log(`Resolved ${resolved.reference} (value redacted)`);
+    useSecret(resolved.value);
+  }
+
+  for (const error of result.errors) {
+    console.log(`Failed to resolve ${error.reference}: ${error.code} - ${error.message}`);
+  }
+}
+
+// Hands the resolved secret to whatever needs it, without logging it.
+function useSecret(_value: string) {}
+//#endregion ResolveSecrets
+
+// Suppress "declared but never read"
+void resolveSecretsExample;


### PR DESCRIPTION
## Description

Adds SDK example coverage for the new `resolveSecrets` operation (`POST /secrets/resolve`, added in 8.10), closing the last remaining example-coverage gap flagged by the daily new-operations check.

Closes #367

### What's in here

Following the convention of recent example-coverage PRs (#336, #346, #349, #360), this PR touches **only** `examples/*`:

- `examples/secret.ts` — a compilable, region-tagged (`//#region ResolveSecrets`) example.
- `examples/operation-map.json` — maps `resolveSecrets` → the new example region.

No ergonomic helper exists for this operation, so the map points at the generated method directly.

No regenerated output is committed. CI's `build` regenerates `src/gen` fresh from the latest upstream spec (which contains `resolveSecrets`), type-checks the example against it, and validates coverage. The committed `src/gen` snapshot is caught up separately by periodic `chore: re-bundle spec` / release PRs.

### Security note

The example never logs a resolved secret value — it prints only the (non-sensitive) reference and hands the value straight to a consumer stub. This mirrors the redaction applied to the equivalent C# example ([csharp#347](https://github.com/camunda/orchestration-cluster-api-csharp/pull/347)) after review feedback: examples get copied verbatim, so they must model safe handling.

### Validation

- Example coverage entry added for `resolveSecrets` (validated by CI against the freshly-bundled spec)
- Biome clean on changed files
- README snippet sync unaffected (no `README.md` / `examples/readme.ts` changes)
