### PR TITLE
ci: add scheduled npm audit workflow (audit follow-up #258/#359)

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,43 @@
+name: npm audit
+
+# Asynchronous (non-merge-blocking) security signal. Runs off the PR-to-merge
+# path on a weekly schedule so dependency vulnerabilities surface via a reliable
+# feedback loop (failed runs show up in the Actions UI and can be wired to
+# notifications) without adding latency to day-to-day merges. Renovate handles
+# the actual fixes (vulnerabilityAlerts + osvVulnerabilityAlerts); this job is
+# the tripwire that a high/critical advisory exists.
+#
+# Scoped to production dependencies (`--omit=dev`): the shipped surface is what
+# matters to users, and excluding dev/tooling transitives keeps the signal high
+# so a red run is always worth acting on rather than noise to be ignored.
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Audit production dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit (fail on high or critical)
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
## Summary

Adds the scheduled `npm audit` job called for by the PLE audit (#355) — the second half of #359 and the resolution of #258. Complements PR #363, which already flipped Renovate's `vulnerabilityAlerts` + `osvVulnerabilityAlerts` on (#359 AC1).

## Change

New `.github/workflows/npm-audit.yml`:

- **Async, non-merge-blocking**: `schedule` (Mondays 06:00 UTC) + `workflow_dispatch`. Kept off the PR-to-merge path so a longer-tail advisory check doesn't add merge latency — the failed run surfaces in the Actions UI instead.
- **Production surface only**: `npm audit --omit=dev --audit-level=high`. Excluding dev/tooling transitives keeps the signal high so a red run is always actionable.
- `permissions: contents: read` only; pinned to the repo's current action majors (`checkout@v6`, `setup-node@v6`) with the cache keyed off `package-lock.json`.

Mirrors the equivalent workflow already running in `c8ctl`.

## Closes

- Closes #258 (`npm audit --audit-level=high` in CI)
- Addresses #359 AC2 (scheduled audit job); #359 AC1 landed in #363

## Not included (with reasons)

- **#356 AC2 — format verification in CI.** Blocked by pre-existing state: `biome format .` currently reports **20 unformatted files on `main`** (e.g. `biome.json`, `BUILDINFO.json`, `assert-json-body.config.json`, `camundacon/**`), mostly CRLF-vs-LF line-ending drift the build's non-verifying `biome format --write` never commits. Adding a format gate requires a repo-wide reformat (+ a `.gitattributes` to enforce LF going forward) first — a noisy, standalone change that would also collide with in-flight generation work. The **lint** half of #356 already landed in #363. Recommend a dedicated PR.
- **#358 — `required_status_checks` on the `Protect main` ruleset.** Requires repo-admin permissions; unchanged from the #363 follow-up note.

## Verification

- `npm audit --omit=dev --audit-level=high` runs the same command locally.
- Workflow YAML validated; LF line endings.
