### PR TITLE
chore: enforce biome check (format + import ordering) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
         run: npm ci
       - name: Generate
         run: npm run generate
-      - name: Lint (Biome)
-        run: npm run lint
+      - name: Lint & format (Biome)
+        run: npm run format:check
       - name: Typecheck
         run: npm run typecheck
 

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,7 @@
       "!coverage",
       "!src/gen",
       "!src/facade",
+      "!json-body-assertions",
       "!.github/workflows",
       "!branding/branding-metadata.json",
       "!tests-integration/methods/manifest.json",

--- a/tests-integration/methods/assignProcessInstanceBusinessId.test.ts
+++ b/tests-integration/methods/assignProcessInstanceBusinessId.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('assignProcessInstanceBusinessId', () => {

--- a/tests-integration/methods/changeClusterMode.test.ts
+++ b/tests-integration/methods/changeClusterMode.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('changeClusterMode', () => {

--- a/tests-integration/methods/createAgentInstance.test.ts
+++ b/tests-integration/methods/createAgentInstance.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('createAgentInstance', () => {

--- a/tests-integration/methods/createAgentInstanceHistoryItem.test.ts
+++ b/tests-integration/methods/createAgentInstanceHistoryItem.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('createAgentInstanceHistoryItem', () => {

--- a/tests-integration/methods/getFormByKey.test.ts
+++ b/tests-integration/methods/getFormByKey.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('getFormByKey', () => {

--- a/tests-integration/methods/getResourceContentBinary.test.ts
+++ b/tests-integration/methods/getResourceContentBinary.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('getResourceContentBinary', () => {

--- a/tests-integration/methods/resolveSecrets.test.ts
+++ b/tests-integration/methods/resolveSecrets.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('resolveSecrets', () => {

--- a/tests-integration/methods/restore.test.ts
+++ b/tests-integration/methods/restore.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('restore', () => {

--- a/tests-integration/methods/resumeProcessInstance.test.ts
+++ b/tests-integration/methods/resumeProcessInstance.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('resumeProcessInstance', () => {

--- a/tests-integration/methods/resumeProcessInstancesBatchOperation.test.ts
+++ b/tests-integration/methods/resumeProcessInstancesBatchOperation.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('resumeProcessInstancesBatchOperation', () => {

--- a/tests-integration/methods/searchAgentInstanceHistory.test.ts
+++ b/tests-integration/methods/searchAgentInstanceHistory.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('searchAgentInstanceHistory', () => {

--- a/tests-integration/methods/searchProcessDefinitionVariableNames.test.ts
+++ b/tests-integration/methods/searchProcessDefinitionVariableNames.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('searchProcessDefinitionVariableNames', () => {

--- a/tests-integration/methods/suspendProcessInstance.test.ts
+++ b/tests-integration/methods/suspendProcessInstance.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('suspendProcessInstance', () => {

--- a/tests-integration/methods/suspendProcessInstancesBatchOperation.test.ts
+++ b/tests-integration/methods/suspendProcessInstancesBatchOperation.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('suspendProcessInstancesBatchOperation', () => {

--- a/tests-integration/methods/updateAgentInstance.test.ts
+++ b/tests-integration/methods/updateAgentInstance.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('updateAgentInstance', () => {

--- a/tests-integration/methods/updateJobsBatchOperation.test.ts
+++ b/tests-integration/methods/updateJobsBatchOperation.test.ts
@@ -1,6 +1,5 @@
 // AUTO-GENERATED SCAFFOLD. You can flesh out the test body; file will not be overwritten once it exists.
 import { describe, it } from 'vitest';
-
 import { createCamundaClient } from '../../dist';
 
 describe('updateJobsBatchOperation', () => {


### PR DESCRIPTION
Stacked on #371 (base = `chore/normalize-line-endings`). Rebase onto `main` once #371 merges.

## What

Closes the format-gate acceptance criterion of #356 (AC2) by wiring the **full `biome check`** (format + lint + import ordering) into CI, replacing the format-blind `biome lint` step.

### Changes
1. **CI gate**: the `quality` job's `Lint (Biome)` step (`npm run lint` = `biome lint .`) is replaced by `Lint & format (Biome)` (`npm run format:check` = `biome check .`). `check` is a superset of `lint`, so this is not double-linting — it adds formatter + `organizeImports` (assist) enforcement.
2. **Mechanical auto-fix**: `biome check --write` organized imports in 16 committed `tests-integration/methods/*.test.ts` scaffolds (blank-line / ordering only — no logic change).
3. **Exclude generated output**: `json-body-assertions/` is added to Biome's ignore list. It is regenerated on every `npm run generate` (via `responses:regenerate:local` → `assert-json-body extract`), and that external tool emits unsorted imports. Since the `quality` job runs `generate` before the check, gating it would fail on regenerated output. This is consistent with `src/gen` / `src/facade` already being excluded.

## Verification
- `biome check .` exits 0 under the **exact CI Biome version (2.5.5)** — only warnings/infos remain, which do not fail the gate.
- No error-severity diagnostics remain.

## Notes
- New OpenAPI operations create fresh integration-test scaffolds during `generate`; a brand-new scaffold may need `npm run lint:fix` (`biome check . --write`) before the gate passes. This is expected and desirable — it keeps scaffolds tidy.
- `#358` (branch-protection required status check) remains blocked on repo-admin access.

Refs #356, #355.