### PR TITLE
fix(gen): derive semantic-key namespace helper types from alias primitive

### DIFF
--- a/plugins/branding-plugin/plugin.ts
+++ b/plugins/branding-plugin/plugin.ts
@@ -137,14 +137,24 @@ export const handler: BrandingPlugin['Handler'] = (ctx) => {
         lines.push(`// ${k.description.replace(/\n/g, ' ')}`);
       }
 
+      // Most semantic keys are string-branded, but some (e.g. LoopIterationId) have an
+      // integer underlying type. Derive the helper value type from the alias's primitive so
+      // getValue/assumeExists/isValid match it — a hardcoded `string` fails to compile for
+      // numeric keys. String-pattern constraints (assertConstraint) only apply to string keys.
+      const aliasPrimitiveMatch = existingTypesGenSource.match(
+        new RegExp(`^export (?:type|interface) ${k.name}\\b[^=]*=\\s*(number|string)\\b`, 'm')
+      );
+      const valueType = aliasPrimitiveMatch?.[1] === 'number' ? 'number' : 'string';
+      const emitConstraint = valueType === 'string' && doValidate && Boolean(c.length);
+
       lines.push(`export namespace ${k.name} {`);
-      lines.push(`  export function ${lifterName}(value: string): ${k.name} {`);
-      if (doValidate && c.length) lines.push(`    assertConstraint(value, '${k.name}', ${obj});`);
+      lines.push(`  export function ${lifterName}(value: ${valueType}): ${k.name} {`);
+      if (emitConstraint) lines.push(`    assertConstraint(value, '${k.name}', ${obj});`);
       lines.push('    return value as any;');
       lines.push('  }');
-      lines.push(`  export function getValue(key: ${k.name}): string { return key; }`);
-      lines.push('  export function isValid(value: string): boolean {');
-      if (doValidate && c.length) {
+      lines.push(`  export function getValue(key: ${k.name}): ${valueType} { return key; }`);
+      lines.push(`  export function isValid(value: ${valueType}): boolean {`);
+      if (emitConstraint) {
         lines.push('    try {');
         lines.push(`      assertConstraint(value, '${k.name}', ${obj});`);
         lines.push('      return true;');


### PR DESCRIPTION
## Problem

CI `test` jobs fail at the **Generate & Build** step (affects every PR against `main`):

```
src/gen/types.gen.ts: error TS2322: Type 'number' is not assignable to type 'string'.
```

CI regenerates `src/gen/` from the live upstream spec. The spec added `LoopIterationId`, a new **int32** semantic key (`export type LoopIterationId = number;`, agent feedback-loop id). The branding plugin emitted its namespace helpers with a hardcoded `string` value type, so `getValue(key: LoopIterationId): string { return key; }` no longer compiled.

## Fix

In `plugins/branding-plugin/plugin.ts`, derive the helper value type (`number | string`) from the key alias's primitive instead of hardcoding `string`. `assumeExists` / `getValue` / `isValid` now match the alias. String-pattern validation (`assertConstraint`) only applies to string keys, so it's gated on the string case.

## Scope

Generator-only change — regenerated `src/gen/` is intentionally **not** committed (CI regenerates fresh, per repo convention). Verified locally: full pipeline regenerates cleanly and the hook-950 example typecheck passes; `LoopIterationId` now emits `number`-typed helpers.

## Defect class

The guard is the existing hook-950 example typecheck in CI: any semantic key whose alias is a non-string primitive would break the previous hardcoded-`string` helpers and fail generation. This fix makes generation correct for the whole class, not just `LoopIterationId`.
