### PR TITLE
chore(deps): override handlebars to 4.7.9 to clear vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4773,9 +4773,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
     "vitest": "^4.1.9"
   },
   "overrides": {
-    "@semantic-release/github": "^11.0.6"
+    "@semantic-release/github": "^11.0.6",
+    "handlebars": "4.7.9"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

Pins **handlebars** to **4.7.9** (from 4.7.8) via npm `overrides` to clear the security advisory.

handlebars is a **transitive, dev-only** dependency — pulled in via `@hey-api/openapi-ts` and `semantic-release` → `conventional-changelog-writer`. It is **not** part of the published `dist`, so runtime exposure to consumers is nil; this is build/release tooling.

4.7.9 is a patch release (semver-compatible with 4.7.8). After the override, `npm ls handlebars` resolves to a single deduped `4.7.9` across the tree, and handlebars no longer appears in `npm audit`.

Only `package.json` (one `overrides` line) and `package-lock.json` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)