### PR TITLE
test: certify Deno and Bun cross-runtime support in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,24 @@ jobs:
           docker logs camunda-engine 2>&1 | tail -200
       - name: Integration Tests
         run: npm run test:integration
+      - name: Set up Deno (cross-runtime live REST)
+        if: matrix.node == '22.x' && matrix.stack == 'simple'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Set up Bun (cross-runtime live REST)
+        if: matrix.node == '22.x' && matrix.stack == 'simple'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Cross-runtime live REST (Node + Deno + Bun vs broker)
+        if: matrix.node == '22.x' && matrix.stack == 'simple'
+        env:
+          # Unprotected docker broker: defaults to auth NONE at localhost:8080.
+          # Setting the address switches the smoke from construct-only to live I/O.
+          CAMUNDA_REST_ADDRESS: http://localhost:8080
+          XR_REQUIRE_RUNTIMES: node,deno,bun
+        run: npm run test:cross-runtime
       - name: Stop Integration Stack
         if: always()
         uses: camunda/sdk-infra/actions/stop-camunda@v1
@@ -206,3 +224,32 @@ jobs:
             fi
             echo "";
           } >> $GITHUB_STEP_SUMMARY
+
+  cross-runtime:
+    name: Cross-runtime (Node + Deno + Bun)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: 'npm'
+          cache-dependency-path: package.json
+      - name: Install deps
+        run: npm ci
+      - name: Generate & Build
+        run: npm run build
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Cross-runtime smoke (packed package, all runtimes)
+        env:
+          XR_REQUIRE_RUNTIMES: node,deno,bun
+        run: npm run test:cross-runtime

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "docs:config": "tsx scripts/generate-config-doc.ts",
     "docs:md": "rm -rf docs-md && typedoc --options typedoc-md.json && node scripts/postprocess-md-docs.mjs docs-md",
     "test:dist": "npm run build --silent && node tests/dist-usage.smoke.mjs",
+    "test:cross-runtime": "node scripts/cross-runtime-smoke.mjs",
     "lint": "biome lint .",
     "lint:fix": "biome check . --write",
     "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",

--- a/scripts/cross-runtime-smoke.mjs
+++ b/scripts/cross-runtime-smoke.mjs
@@ -1,0 +1,136 @@
+// Cross-runtime smoke orchestrator.
+//
+// Builds a real consumer of the *packed* package (so we test the published
+// artifact + its resolved dependency tree, not the source tree) and runs
+// tests/cross-runtime.smoke.mjs under every available JavaScript runtime
+// (Node, Deno, Bun). This certifies that the shipped package loads, constructs
+// a client, and — when a broker is reachable — performs live REST I/O on each
+// runtime.
+//
+// Usage:
+//   node scripts/cross-runtime-smoke.mjs
+//
+// Env:
+//   XR_RUNTIMES            comma list to restrict runtimes (default: all found)
+//   XR_REQUIRE_RUNTIMES    comma list that MUST be present or the run fails
+//   CAMUNDA_REST_ADDRESS   when set, the smoke also does live REST I/O
+//   XR_PROCESS_ID          when set (with a broker), also creates an instance
+//   (all other CAMUNDA_* vars are passed through for auth)
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const smokeSrc = join(repoRoot, 'tests', 'cross-runtime.smoke.mjs');
+
+/** Resolve a runtime binary on PATH, returning null when absent. */
+function which(bin) {
+  const r = spawnSync(process.platform === 'win32' ? 'where' : 'which', [bin], {
+    encoding: 'utf8',
+  });
+  return r.status === 0 ? bin : null;
+}
+
+const ALL = [
+  { name: 'node', bin: 'node', args: (f) => [f] },
+  // Deno needs an explicit node_modules mode for a file:-installed npm package.
+  { name: 'deno', bin: 'deno', args: (f) => ['run', '--node-modules-dir=manual', '-A', f] },
+  { name: 'bun', bin: 'bun', args: (f) => [f] },
+];
+
+const only = (process.env.XR_RUNTIMES ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+const required = (process.env.XR_REQUIRE_RUNTIMES ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const selected = ALL.filter((r) => (only.length ? only.includes(r.name) : true));
+
+const log = (...a) => console.log('[cross-runtime]', ...a);
+
+// 1. Pack the built package.
+const tmp = mkdtempSync(join(tmpdir(), 'oca-cross-runtime-'));
+log(`workdir ${tmp}`);
+let tarball;
+try {
+  const packed = execFileSync('npm', ['pack', '--silent', '--pack-destination', tmp], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .pop();
+  tarball = join(tmp, packed);
+  log(`packed ${packed}`);
+} catch (e) {
+  console.error('[cross-runtime] npm pack failed:', e.message);
+  process.exit(1);
+}
+
+// 2. Isolated consumer with a real (non-symlinked) dependency tree.
+const consumer = join(tmp, 'consumer');
+try {
+  mkdirSync(consumer, { recursive: true });
+  writeFileSync(
+    join(consumer, 'package.json'),
+    JSON.stringify(
+      { name: 'oca-cross-runtime-consumer', private: true, type: 'module', version: '0.0.0' },
+      null,
+      2
+    )
+  );
+  execFileSync('npm', ['install', tarball, '--silent', '--no-audit', '--no-fund'], {
+    cwd: consumer,
+    encoding: 'utf8',
+  });
+  writeFileSync(join(consumer, 'smoke.mjs'), readFileSync(smokeSrc, 'utf8'));
+  log('installed packed package into isolated consumer');
+} catch (e) {
+  console.error('[cross-runtime] consumer setup failed:', e.message);
+  process.exit(1);
+}
+
+// 3. Run the smoke under each available runtime.
+const results = [];
+for (const rt of selected) {
+  const present = which(rt.bin);
+  if (!present) {
+    if (required.includes(rt.name)) {
+      results.push({ name: rt.name, status: 'MISSING (required)' });
+    } else {
+      log(`skip ${rt.name} (not installed)`);
+    }
+    continue;
+  }
+  log(`running under ${rt.name}...`);
+  const r = spawnSync(rt.bin, rt.args(join(consumer, 'smoke.mjs')), {
+    cwd: consumer,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  results.push({ name: rt.name, status: r.status === 0 ? 'PASS' : `FAIL (exit ${r.status})` });
+}
+
+// 4. Report + cleanup.
+try {
+  rmSync(tmp, { recursive: true, force: true });
+} catch {
+  /* best-effort */
+}
+
+console.log('\n[cross-runtime] summary:');
+for (const r of results) console.log(`  - ${r.name}: ${r.status}`);
+
+const ok = results.length > 0 && results.every((r) => r.status === 'PASS');
+if (!ok) {
+  console.error('[cross-runtime] one or more runtimes failed');
+  process.exit(1);
+}
+console.log('[cross-runtime] all runtimes passed');

--- a/scripts/cross-runtime-smoke.mjs
+++ b/scripts/cross-runtime-smoke.mjs
@@ -37,7 +37,20 @@ function which(bin) {
 const ALL = [
   { name: 'node', bin: 'node', args: (f) => [f] },
   // Deno needs an explicit node_modules mode for a file:-installed npm package.
-  { name: 'deno', bin: 'deno', args: (f) => ['run', '--node-modules-dir=manual', '-A', f] },
+  // Scope permissions to what the smoke actually needs: env (read CAMUNDA_*),
+  // read (node_modules + script), and net (optional live REST I/O).
+  {
+    name: 'deno',
+    bin: 'deno',
+    args: (f) => [
+      'run',
+      '--node-modules-dir=manual',
+      '--allow-env',
+      '--allow-read',
+      '--allow-net',
+      f,
+    ],
+  },
   { name: 'bun', bin: 'bun', args: (f) => [f] },
 ];
 
@@ -51,6 +64,19 @@ const required = (process.env.XR_REQUIRE_RUNTIMES ?? '')
   .filter(Boolean);
 
 const selected = ALL.filter((r) => (only.length ? only.includes(r.name) : true));
+
+// A required runtime that the XR_RUNTIMES filter excludes (or that names an
+// unknown runtime) can never run, so treat that contradictory configuration as
+// a failure rather than silently dropping the requirement.
+const selectedNames = new Set(selected.map((r) => r.name));
+const excludedRequired = required.filter((name) => !selectedNames.has(name));
+if (excludedRequired.length) {
+  console.error(
+    `[cross-runtime] required runtime(s) not selectable: ${excludedRequired.join(', ')}` +
+      ' (excluded by XR_RUNTIMES or unknown)'
+  );
+  process.exit(1);
+}
 
 const log = (...a) => console.log('[cross-runtime]', ...a);
 

--- a/tests/cross-runtime.smoke.mjs
+++ b/tests/cross-runtime.smoke.mjs
@@ -1,0 +1,82 @@
+// Cross-runtime smoke test for the built package.
+//
+// Verifies that the published artifact loads, constructs a client, and (when a
+// broker is reachable) performs live REST I/O on Node, Deno, and Bun. The
+// client is a `@hey-api/client-fetch` (Web `fetch`) client and every `node:`
+// import in the runtime is dynamic + peripheral (OAuth file cache, worker-thread
+// pool, support logger), so the module graph is spec-strict-runtime safe. This
+// test guards that property against regressions.
+//
+// It is meant to run FROM A CONSUMER project that has installed the package
+// (see scripts/cross-runtime-smoke.mjs), so it imports the package by its bare
+// specifier — exactly how a real consumer does.
+//
+// Behaviour is env-driven:
+//   - Always: import + construct + key-branding + Request-init sanitize checks.
+//   - When CAMUNDA_REST_ADDRESS (or ZEEBE_REST_ADDRESS) is set: a live
+//     `getTopology()` GET, plus a `createProcessInstance` POST when
+//     XR_PROCESS_ID names a deployed process. Auth is taken from the standard
+//     CAMUNDA_* environment.
+
+import { createCamundaClient, ProcessDefinitionKey } from '@camunda8/orchestration-cluster-api';
+
+/** Read an env var portably (Deno uses Deno.env; Node/Bun use process.env). */
+const env = (key) => {
+  const g = globalThis;
+  if (g.Deno?.env?.get) return g.Deno.env.get(key);
+  return g.process?.env?.[key];
+};
+
+const runtime = globalThis.Deno
+  ? `Deno ${globalThis.Deno.version.deno}`
+  : globalThis.Bun
+    ? `Bun ${globalThis.Bun.version}`
+    : `Node ${globalThis.process?.versions?.node ?? '?'}`;
+
+const fail = (msg) => {
+  console.error(`[cross-runtime] FAIL on ${runtime}: ${msg}`);
+  const exit = globalThis.Deno?.exit ?? globalThis.process?.exit;
+  exit?.(1);
+  throw new Error(msg);
+};
+
+console.log(
+  `[cross-runtime] runtime=${runtime} fetch=${typeof fetch} WebSocket=${typeof WebSocket}`
+);
+
+// 1. Import + shape.
+if (typeof createCamundaClient !== 'function') fail('createCamundaClient is not a function');
+
+// 2. Branded-key helper roundtrips (exercises a representative runtime util).
+if (String(ProcessDefinitionKey.assumeExists('42')) !== '42') fail('key branding roundtrip failed');
+
+// 3. Construct a client. On spec-strict runtimes (Deno, Bun) an unsanitized
+//    RequestInit throws when a Request is built; constructing (and, below,
+//    issuing a request) exercises that path.
+const restAddress = env('CAMUNDA_REST_ADDRESS') ?? env('ZEEBE_REST_ADDRESS');
+const client = createCamundaClient();
+if (!client || typeof client.getTopology !== 'function') fail('client missing getTopology');
+console.log('[cross-runtime] import + construct + branding OK');
+
+// 4. Live REST I/O (only when a broker address is configured).
+if (restAddress) {
+  const topo = await client.getTopology();
+  const gatewayVersion = topo?.gatewayVersion ?? topo?.brokers?.[0]?.version;
+  if (!topo?.brokers?.length)
+    fail(`getTopology returned no brokers: ${JSON.stringify(topo).slice(0, 200)}`);
+  console.log(`[cross-runtime] live getTopology OK (gatewayVersion=${gatewayVersion})`);
+
+  const processDefinitionId = env('XR_PROCESS_ID');
+  if (processDefinitionId) {
+    const inst = await client.createProcessInstance({ processDefinitionId });
+    const key = inst?.processInstanceKey ?? inst?.key;
+    if (!key) fail(`createProcessInstance returned no key: ${JSON.stringify(inst).slice(0, 200)}`);
+    console.log(`[cross-runtime] live createProcessInstance OK (processInstanceKey=${key})`);
+  } else {
+    console.log('[cross-runtime] XR_PROCESS_ID unset — skipping create-instance');
+  }
+} else {
+  console.log('[cross-runtime] CAMUNDA_REST_ADDRESS unset — construct-only (no live I/O)');
+}
+
+console.log(`[cross-runtime] PASS on ${runtime}`);

--- a/tests/cross-runtime.smoke.mjs
+++ b/tests/cross-runtime.smoke.mjs
@@ -12,11 +12,13 @@
 // specifier — exactly how a real consumer does.
 //
 // Behaviour is env-driven:
-//   - Always: import + construct + key-branding + Request-init sanitize checks.
+//   - Always: import + construct + key-branding checks.
 //   - When CAMUNDA_REST_ADDRESS (or ZEEBE_REST_ADDRESS) is set: a live
 //     `getTopology()` GET, plus a `createProcessInstance` POST when
-//     XR_PROCESS_ID names a deployed process. Auth is taken from the standard
-//     CAMUNDA_* environment.
+//     XR_PROCESS_ID names a deployed process. Issuing a request is what builds
+//     a `Request` and therefore exercises the Request-init sanitize path on
+//     spec-strict runtimes. Auth is taken from the standard CAMUNDA_*
+//     environment.
 
 import { createCamundaClient, ProcessDefinitionKey } from '@camunda8/orchestration-cluster-api';
 


### PR DESCRIPTION
## Why

The client transport is Web-standard `fetch` (`@hey-api/client-fetch` over `globalThis.fetch` + `new Request(...)`), and the repo already carries a Deno/Bun request-init compat hook (`hooks/post/630-fix-request-init-runtime-compat.ts`). So the package is *designed* to run on Deno and Bun, but CI only ever exercised **Node**, leaving cross-runtime support unverified and free to silently regress.

## What

- **`tests/cross-runtime.smoke.mjs`** &mdash; a runtime-agnostic smoke. Imports the package by its bare specifier, reads env portably (`Deno.env` vs `process.env`), asserts `createCamundaClient` + `ProcessDefinitionKey` branding roundtrip + `getTopology` presence, and (when `CAMUNDA_REST_ADDRESS` is set) performs live `getTopology()` and, with `XR_PROCESS_ID`, `createProcessInstance`.
- **`scripts/cross-runtime-smoke.mjs`** (`npm run test:cross-runtime`) &mdash; orchestrator that `npm pack`s the built package, installs the **tarball** into an isolated temp consumer (a real, non-symlinked dependency tree, so we test the shipped artifact + resolved deps, not the source tree), and runs the smoke under every available runtime (Node always; Deno with `--node-modules-dir=manual`; Bun). Env knobs: `XR_RUNTIMES`, `XR_REQUIRE_RUNTIMES`, `CAMUNDA_REST_ADDRESS`, `XR_PROCESS_ID`.
- **CI (`ci.yml`)**:
  - a hermetic **`cross-runtime`** job (no broker): build, then run the smoke on Node + Deno + Bun (construct + branding);
  - a **live-REST** step in the existing broker-backed `test` job (node 22 / simple) that runs the smoke under Node + Deno + Bun against the integration broker (unprotected, auth `NONE` at `localhost:8080`).

## Evidence (local, against a live broker)

| runtime | import+construct | live `getTopology` | live `createProcessInstance` |
|---|---|---|---|
| Node 24.15 | pass | pass | pass |
| Deno 2.8.2 | pass | pass | pass |
| Bun 1.3.14 | pass | pass | pass |

All three runtimes pass import, construct, live `getTopology`, and `createProcessInstance`.
