### PR TITLE
fix(worker): buffer start() until the transport is ready

### DIFF
--- a/src/runtime/jobWorker.ts
+++ b/src/runtime/jobWorker.ts
@@ -2,6 +2,7 @@ import type { z } from 'zod';
 import type { CamundaClient } from '../gen/CamundaClient';
 import type { ActivateJobsResponses } from '../gen/types.gen';
 import type { EnrichedActivatedJob } from './jobActions';
+import { WorkerStartGate } from './workerStartGate';
 
 type ActivatedJobResult = ActivateJobsResponses[200]['jobs'][number];
 
@@ -100,6 +101,7 @@ export class JobWorker {
   private _pollTimer: any = null;
   private _inFlightActivation: any = null; // CancelablePromise-like
   private _log: ReturnType<CamundaClient['logger']>;
+  private _startGate: WorkerStartGate;
 
   constructor(client: CamundaClient, cfg: JobWorkerConfig) {
     this._client = client;
@@ -124,6 +126,14 @@ export class JobWorker {
         { maxBackoffTimeMs: cfg.maxBackoffTimeMs },
       ]);
     }
+    // The plain worker's transport (the HTTP client) is constructed synchronously,
+    // so its readiness signal is already-resolved. The gate is still required: it
+    // holds the first poll until after the tick in which the factory returns the
+    // handle, and it makes start() idempotent across the whole worker lifetime.
+    this._startGate = new WorkerStartGate(
+      () => Promise.resolve(),
+      () => this._stopped
+    );
     if (this._cfg.autoStart) this.start();
   }
 
@@ -137,10 +147,26 @@ export class JobWorker {
     return this._stopped;
   }
 
+  /**
+   * Begin polling for jobs. Safe to call at any point: the request is buffered
+   * until the transport is ready, and redundant calls (including an explicit
+   * call on an `autoStart` worker) are dropped rather than starting a second
+   * poll loop. Once the worker is stopped, `start()` is a no-op.
+   */
   start() {
     if (this._stopped) return;
-    if (this._pollTimer) return; // already running
+    const accepted = this._startGate.request(
+      () => this._beginPolling(),
+      (err) => this._log.error('worker.start.transportError', err)
+    );
+    if (!accepted) {
+      this._log.debug('worker.start.alreadyRequested');
+      return;
+    }
     this._log.info('worker.start');
+  }
+
+  private _beginPolling() {
     const jitterMax = this._cfg.startupJitterMaxSeconds ?? 0;
     if (jitterMax > 0) {
       const jitterMs = Math.floor(Math.random() * jitterMax * 1000);

--- a/src/runtime/threadedJobWorker.ts
+++ b/src/runtime/threadedJobWorker.ts
@@ -4,6 +4,7 @@ import type { ActivateJobsResponses } from '../gen/types.gen';
 import type { EnrichedActivatedJob } from './jobActions';
 import type { JobActionReceipt } from './jobWorker';
 import type { ThreadPool } from './threadPool';
+import { WorkerStartGate } from './workerStartGate';
 
 type ActivatedJobResult = ActivateJobsResponses[200]['jobs'][number];
 
@@ -130,6 +131,7 @@ export class ThreadedJobWorker {
   private _inFlightActivation: any = null;
   private _log: ReturnType<CamundaClient['logger']>;
   private _jobQueue: Array<{ raw: ActivatedJobResult & Partial<EnrichedActivatedJob> }> = [];
+  private _startGate: WorkerStartGate;
 
   constructor(client: CamundaClient, pool: ThreadPool, cfg: ThreadedJobWorkerConfig) {
     this._client = client;
@@ -153,6 +155,13 @@ export class ThreadedJobWorker {
     // Drain queued jobs when a thread becomes ready or idle
     this._pool.onThreadReady = () => this._drainQueue();
 
+    // The shared thread pool spawns its threads asynchronously, so the handle is
+    // returned before the transport can service a poll. Buffer start requests on
+    // the pool's readiness signal.
+    this._startGate = new WorkerStartGate(
+      () => this._pool.ready,
+      () => this._stopped
+    );
     if (this._cfg.autoStart) this.start();
   }
 
@@ -178,10 +187,26 @@ export class ThreadedJobWorker {
     return this._pool.ready;
   }
 
+  /**
+   * Begin polling for jobs. Safe to call at any point: the request is buffered
+   * until the shared thread pool is ready, and redundant calls (including an
+   * explicit call on an `autoStart` worker) are dropped rather than starting a
+   * second poll loop. Once the worker is stopped, `start()` is a no-op.
+   */
   start() {
     if (this._stopped) return;
-    if (this._pollTimer) return;
+    const accepted = this._startGate.request(
+      () => this._beginPolling(),
+      (err) => this._log.error('worker.start.transportError', err)
+    );
+    if (!accepted) {
+      this._log.debug('worker.start.alreadyRequested');
+      return;
+    }
     this._log.info('worker.start');
+  }
+
+  private _beginPolling() {
     const jitterMax = this._cfg.startupJitterMaxSeconds ?? 0;
     if (jitterMax > 0) {
       const jitterMs = Math.floor(Math.random() * jitterMax * 1000);
@@ -358,7 +383,8 @@ export class ThreadedJobWorker {
   private async _poll() {
     this._pollTimer = null;
     if (this._stopped) return;
-    // Ensure shared thread pool is ready before polling
+    // Belt and braces: the start gate already held the first poll until the pool
+    // was ready, so by here this resolves immediately.
     await this._pool.ready;
     if (this._activeJobs >= this._maxParallelJobs) {
       this._scheduleNext(this._cfg.pollIntervalMs);

--- a/src/runtime/workerStartGate.ts
+++ b/src/runtime/workerStartGate.ts
@@ -1,0 +1,62 @@
+/**
+ * Buffers a job worker's `start()` request until its transport is ready to
+ * service polls.
+ *
+ * `createJobWorker` / `createThreadedJobWorker` return the worker handle
+ * synchronously, but the transport behind it may still be initialising — the
+ * threaded worker's shared thread pool spawns its threads asynchronously. A
+ * `start()` issued in that window used to schedule a poll against a transport
+ * that was not up yet.
+ *
+ * The gate also owns start idempotency. Guarding on the poll timer alone is not
+ * enough: the timer is null for the whole duration of an in-flight activation,
+ * so a `start()` landing in that window opened a *second* concurrent poll loop
+ * alongside the first — which is what an `autoStart: true` worker plus an eager
+ * app-side `start()` produces. Once a request is accepted the gate drops every
+ * later one, so autostart and an explicit caller cannot both kick off polling.
+ *
+ * See https://github.com/camunda/orchestration-cluster-api-js/issues/401.
+ */
+export class WorkerStartGate {
+  private _requested = false;
+
+  /**
+   * @param transportReady Resolves when the worker's transport can service polls.
+   * @param isStopped Reports whether the worker was stopped while the gate was buffering.
+   */
+  constructor(
+    private readonly _transportReady: () => Promise<void>,
+    private readonly _isStopped: () => boolean
+  ) {}
+
+  /** True once a start request has been accepted and not since released. */
+  get requested(): boolean {
+    return this._requested;
+  }
+
+  /**
+   * Record a start request.
+   *
+   * The first accepted request invokes `onReady` once the transport resolves,
+   * and only if the worker has not been stopped in the meantime. If the
+   * transport fails to come up, `onError` is invoked and the gate is released so
+   * a later `start()` can retry.
+   *
+   * @returns `false` when the request was dropped as redundant.
+   */
+  request(onReady: () => void, onError: (err: unknown) => void): boolean {
+    if (this._requested) return false;
+    this._requested = true;
+    void this._transportReady().then(
+      () => {
+        if (this._isStopped()) return;
+        onReady();
+      },
+      (err) => {
+        this._requested = false;
+        onError(err);
+      }
+    );
+    return true;
+  }
+}

--- a/tests/worker-start-gate.test.ts
+++ b/tests/worker-start-gate.test.ts
@@ -1,0 +1,220 @@
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createCamundaClient } from '../src';
+
+/**
+ * Regression tests for the worker start gate (issue #401).
+ *
+ * `createJobWorker` / `createThreadedJobWorker` return the worker handle
+ * synchronously while the transport behind it may still be initialising, and
+ * `start()` used to schedule a poll immediately. Its only guard was
+ * `if (this._pollTimer) return`, which is released for the whole duration of an
+ * in-flight activation — so a `start()` issued in that window opened a *second*
+ * concurrent poll loop alongside the first (autostart + an eager app-side
+ * `start()` is exactly that shape).
+ *
+ * These tests are written against the *class* of defect rather than one worker:
+ * every kind in `WORKER_KINDS` must satisfy the same `start()` contract, so a
+ * new worker type that reimplements `start()` without the gate fails here.
+ *
+ * The invariant they assert is transport-level and does not depend on wall
+ * clock: **a correctly gated worker never has two activation requests in flight
+ * at the same time**, no matter how often or when `start()` is called.
+ */
+
+const REST_ADDRESS = 'http://localhost:8080';
+const JOB_TYPE = 'start-gate-task';
+
+interface WorkerHandle {
+  start(): void;
+  stop(): void;
+  readonly stopped: boolean;
+  readonly ready?: Promise<void>;
+}
+
+interface WorkerKind {
+  name: string;
+  create(client: any, autoStart: boolean): WorkerHandle;
+  /** Resolves when this kind's transport is up; undefined when it has no async transport. */
+  transportReady(worker: WorkerHandle): Promise<void> | undefined;
+}
+
+const WORKER_KINDS: WorkerKind[] = [
+  {
+    name: 'JobWorker',
+    create: (client, autoStart) =>
+      client.createJobWorker({
+        jobType: JOB_TYPE,
+        jobHandler: async (job: any) => job.complete(),
+        maxParallelJobs: 1,
+        autoStart,
+      }),
+    transportReady: () => undefined,
+  },
+  {
+    name: 'ThreadedJobWorker',
+    create: (client, autoStart) =>
+      client.createThreadedJobWorker({
+        jobType: JOB_TYPE,
+        handlerModule: path.join(__dirname, 'fixtures/threaded-handler-complete.js'),
+        maxParallelJobs: 1,
+        threadPoolSize: 1,
+        autoStart,
+      }),
+    transportReady: (worker) => worker.ready,
+  },
+];
+
+/** Tracks concurrent activation requests so a duplicated poll loop is observable. */
+interface ActivationProbe {
+  /** Total activation requests seen. */
+  count: number;
+  /** Highest number of activation requests in flight simultaneously. */
+  maxInFlight: number;
+  inFlight: number;
+  /** Invoked while an activation is in flight; the returned promise gates the response. */
+  onActivation?: (count: number) => Promise<void> | void;
+}
+
+function createProbedClient(probe: ActivationProbe) {
+  return createCamundaClient({
+    config: { CAMUNDA_REST_ADDRESS: REST_ADDRESS },
+    log: { level: 'error' },
+    fetch: (async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (!url.includes('/v2/jobs/activation')) {
+        return new Response(JSON.stringify({ error: `No mock for ${url}` }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      probe.count++;
+      probe.inFlight++;
+      probe.maxInFlight = Math.max(probe.maxInFlight, probe.inFlight);
+      try {
+        await probe.onActivation?.(probe.count);
+      } finally {
+        probe.inFlight--;
+      }
+      return new Response(JSON.stringify({ jobs: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as any,
+  });
+}
+
+/**
+ * Yield the macrotask queue up to `turns` times, stopping early once `until` holds.
+ *
+ * A wrongly-scheduled poll is queued with `setTimeout(..., 0)`, so it surfaces
+ * within a couple of turns; the budget is a safety net, not a correctness
+ * signal — the assertions never depend on how long a turn takes.
+ */
+async function drainTurns(turns: number, until: () => boolean): Promise<void> {
+  for (let i = 0; i < turns && !until(); i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+async function waitFor(condition: () => boolean, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (!condition() && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  if (!condition()) throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
+describe('worker start gate', () => {
+  let client: any = null;
+
+  afterEach(() => {
+    client?.stopAllWorkers();
+    client = null;
+  });
+
+  for (const kind of WORKER_KINDS) {
+    describe(kind.name, () => {
+      it('drops an explicit start() issued while an activation is in flight', async () => {
+        const probe: ActivationProbe = { count: 0, inFlight: 0, maxInFlight: 0 };
+        client = createProbedClient(probe);
+        let worker: WorkerHandle | null = null;
+
+        probe.onActivation = async () => {
+          // Re-enter start() precisely while an activation is outstanding. This is
+          // the window in which _pollTimer is null, so a timer-only guard admits a
+          // second poll loop; the gate must drop the request instead.
+          worker?.start();
+          worker?.start();
+          await drainTurns(25, () => probe.inFlight > 1);
+        };
+
+        worker = kind.create(client, true);
+        await waitFor(() => probe.count >= 2, 5000);
+        worker.stop();
+
+        expect(probe.maxInFlight).toBe(1);
+      });
+
+      it('is idempotent when start() is called repeatedly in the creation tick', async () => {
+        const probe: ActivationProbe = { count: 0, inFlight: 0, maxInFlight: 0 };
+        client = createProbedClient(probe);
+
+        const worker = kind.create(client, false);
+        worker.start();
+        worker.start();
+        worker.start();
+
+        // No poll may be issued in the tick that created the handle.
+        expect(probe.count).toBe(0);
+
+        probe.onActivation = async () => {
+          worker.start();
+          await drainTurns(25, () => probe.inFlight > 1);
+        };
+
+        await waitFor(() => probe.count >= 2, 5000);
+        worker.stop();
+
+        expect(probe.maxInFlight).toBe(1);
+      });
+
+      it('does not activate before the transport signals ready', async () => {
+        const probe: ActivationProbe = { count: 0, inFlight: 0, maxInFlight: 0 };
+        client = createProbedClient(probe);
+
+        const worker = kind.create(client, false);
+        worker.start();
+
+        const ready = kind.transportReady(worker);
+        if (ready) {
+          let readyResolved = false;
+          void ready.then(() => {
+            readyResolved = true;
+          });
+          await waitFor(() => probe.count >= 1, 5000);
+          expect(readyResolved).toBe(true);
+        } else {
+          await waitFor(() => probe.count >= 1, 5000);
+        }
+        worker.stop();
+      });
+
+      it('start() after stop() stays a no-op', async () => {
+        const probe: ActivationProbe = { count: 0, inFlight: 0, maxInFlight: 0 };
+        client = createProbedClient(probe);
+
+        const worker = kind.create(client, false);
+        worker.stop();
+        worker.start();
+        worker.start();
+
+        await drainTurns(25, () => probe.count > 0);
+
+        expect(worker.stopped).toBe(true);
+        expect(probe.count).toBe(0);
+      });
+    });
+  }
+});


### PR DESCRIPTION
Fixes #401

## The defect

`createJobWorker` / `createThreadedJobWorker` return the worker handle synchronously, but the transport behind it may still be initialising — the threaded worker's shared thread pool spawns its threads asynchronously. `start()` scheduled the first poll immediately, guarded only by `if (this._pollTimer) return`.

That guard is insufficient in a way the issue only implies. `_poll()` sets `_pollTimer` to `null` on entry, so **the timer is null for the entire duration of an in-flight activation**. A `start()` landing in that window opened a *second concurrent poll loop* alongside the first — which is exactly what an `autoStart: true` worker plus an eager app-side `start()` produces.

One correction to the issue's framing: `ThreadedJobWorker._poll()` already did `await this._pool.ready`, so it never actually activated against a dead pool. But that await is precisely what widens the null-timer window during pool init, making the duplicate-loop hole easier to hit on the threaded path.

## The fix

New `src/runtime/workerStartGate.ts`. `WorkerStartGate` buffers the start intent on a transport-readiness promise, flushes it once, and drops every later request.

- `ThreadedJobWorker` gates on the shared pool's `ready` promise.
- `JobWorker` gates on an already-resolved promise — its HTTP transport is built synchronously, but the gate still holds the first poll until after the tick in which the factory returns the handle, and makes `start()` idempotent for the worker's whole lifetime.
- **Autostart drop falls out of idempotency.** The constructor takes the gate; an explicit `start()` is then a no-op. No separate flag, so the two paths cannot double-start.
- A transport that fails to come up is now logged as `worker.start.transportError` and releases the gate so a later `start()` can retry. Previously a pool-init rejection surfaced as an unhandled rejection out of the timer callback.
- The `stopped` guard still wins: `start()` after `stop()` remains a no-op.

Both workers keep `_pollTimer` for scheduling; it is no longer load-bearing as a start guard.

## Test

`tests/worker-start-gate.test.ts`, written against the class of defect rather than one worker. The same contract runs over a `WORKER_KINDS` table (`JobWorker`, `ThreadedJobWorker`), so a future worker type that reimplements `start()` without the gate fails here.

The invariant is transport-level and has no wall-clock dependency: **a correctly gated worker never has two activation requests in flight at the same time**, however often or whenever `start()` is called. The probe re-enters `start()` from inside the fetch mock, exactly while an activation is outstanding, then drains a bounded number of macrotask turns — a wrongly-scheduled poll is queued with `setTimeout(..., 0)` and surfaces within a couple of turns. The turn budget is a safety net, not a correctness signal.

Cases per worker kind:
1. explicit `start()` during an in-flight activation is dropped
2. repeated `start()` in the creation tick is idempotent, and no poll is issued in that tick
3. no activation before the transport signals ready
4. `start()` after `stop()` stays a no-op

Red (before the fix): 4 failed, `expected 2 to be 1`, both worker kinds, both duplicate-loop cases. Green: 8/8, stable over 5 consecutive runs.

## Verification

- New suite: 8/8, run 5× consecutively.
- Full unit suite: 233 passed, up from 225 on the clean tree. **No new failures.**
- `tsc --noEmit -p tsconfig.typecheck.json`: clean.
- `biome check` on all four touched files: clean.

## Notes for the reviewer

No generator, template, or `src/gen` surface is touched, so no regenerated-output commit is needed.

I could not run the full `npm run build` locally: on Windows the npm scripts shell to `cmd.exe` and the POSIX env-var prefixes (`CAMUNDA_SDK_INTEGRATION=0 vitest ...`) fail to parse, so I ran vitest, tsc, and biome directly. CI will cover the build.

Separately, the clean tree already fails 8 unit tests on Windows (identical set before and after this change) — a `pathToFileURL` bug in `threadWorkerEntry.ts` that breaks threaded workers on Windows, and a hardcoded `/tmp` in `tests/mtls.test.ts`. Both are out of scope here and will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
