### PR TITLE
fix(runtime): reject transport errors instead of silently swallowing them

### DIFF
--- a/src/runtime/responseEvaluation.ts
+++ b/src/runtime/responseEvaluation.ts
@@ -12,6 +12,22 @@ export function evaluateSdkResponse(raw: any, opts: EvalOptions) {
   // Support nested problem payload under raw.error without top-level status
   const status = raw.status || raw.response?.status || raw.error?.status;
   if (!status) {
+    // No discernible HTTP status. Since the generated client wraps the `fetch`
+    // call in a try/catch (>= v10.0.0-alpha.18) and, with throwOnError:false,
+    // *returns* `{ error, response: undefined }` on a transport failure instead
+    // of rejecting, a status-less `raw` with an `error` and no `data` is a
+    // transport/connection error (DNS, ECONNREFUSED, unreachable host, TLS).
+    // It must surface as a rejection, not be unwrapped as success. See issue
+    // camunda/orchestration-cluster-api-js#405.
+    if (raw.error !== undefined && raw.data === undefined) {
+      const e = raw.error;
+      if (e instanceof Error) throw e;
+      const err: any = new Error(String(e?.message ?? e ?? `transport error [${opts.opId}]`));
+      err.name = 'TransportSdkError';
+      err.operationId = opts.opId;
+      err.cause = e;
+      throw err;
+    }
     // No discernible HTTP status: unwrap data if present
     return raw.data !== undefined ? raw.data : raw;
   }

--- a/tests/transport-error-rejection.test.ts
+++ b/tests/transport-error-rejection.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCamundaClient } from '../src';
+import { createCamundaFpClient, isLeft } from '../src/fp';
+import { evaluateSdkResponse } from '../src/runtime/responseEvaluation';
+
+// Regression guard for camunda/orchestration-cluster-api-js#405.
+//
+// The class of behavioural change this locks down: an operation that used to
+// REJECT on a transport/connection failure (DNS, ECONNREFUSED, unreachable
+// host, TLS) starts RESOLVING (undefined / a Left of nothing) instead — i.e.
+// the SDK silently swallows a failed request. This slipped in with the
+// generated-client upgrade (>= v10.0.0-alpha.18) that moved `await fetch(...)`
+// inside a try/catch and, with throwOnError:false, RETURNS `{ error }` on a
+// transport error rather than throwing.
+//
+// These tests assert the *public contract* at the surface a user actually
+// touches, independent of the internal path (client -> evaluateSdkResponse ->
+// class method / fp wrapper). Any future refactor that reintroduces swallowing
+// on any of these operations fails here.
+
+// A failing transport: fetch itself rejects, exactly as a real connection error
+// would. Assigned per-test so we can count invocations.
+function failingFetch() {
+  return vi.fn(async () => {
+    throw new TypeError('fetch failed');
+  });
+}
+
+const CONFIG = {
+  CAMUNDA_REST_ADDRESS: 'https://example.invalid',
+  CAMUNDA_AUTH_STRATEGY: 'NONE',
+  // Keep the (possible) retry loop tiny and fast so the test stays deterministic.
+  CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS: 1,
+  CAMUNDA_SDK_HTTP_RETRY_BASE_DELAY_MS: 1,
+  CAMUNDA_SDK_HTTP_RETRY_MAX_DELAY_MS: 5,
+} as const;
+
+// A representative spread of generated method shapes: a no-body GET, a
+// POST-with-body, an enriched job op, and a search op. They all share the same
+// transport, so if any one starts swallowing, the generator/runtime changed the
+// contract for its whole class.
+const OPERATIONS: Array<{ name: string; call: (c: any) => Promise<unknown> }> = [
+  { name: 'getTopology (GET, no body)', call: (c) => c.getTopology() },
+  {
+    name: 'correlateMessage (POST body)',
+    call: (c) => c.correlateMessage({ name: 'x', correlationKey: 'k' }),
+  },
+  {
+    name: 'activateJobs (POST body, enriched)',
+    call: (c) => c.activateJobs({ type: 'x', timeout: 1000, maxJobsToActivate: 1 }),
+  },
+  {
+    name: 'searchProcessInstances (POST search)',
+    call: (c) => c.searchProcessInstances({}, { consistency: { waitUpToMs: 0 } }),
+  },
+];
+
+describe('transport-error rejection contract (#405)', () => {
+  describe('unit: evaluateSdkResponse', () => {
+    it('throws when there is an error but no HTTP status (transport failure)', () => {
+      const raw = { error: new TypeError('fetch failed'), request: {}, response: undefined };
+      expect(() => evaluateSdkResponse(raw, { opId: 'correlateMessage' })).toThrow(/fetch failed/);
+    });
+
+    it('wraps a non-Error transport error with a TransportSdkError carrying the operationId', () => {
+      try {
+        evaluateSdkResponse({ error: 'boom', response: undefined }, { opId: 'correlateMessage' });
+        throw new Error('expected throw');
+      } catch (e: any) {
+        expect(e.name).toBe('TransportSdkError');
+        expect(e.operationId).toBe('correlateMessage');
+        expect(String(e.message)).toContain('boom');
+      }
+    });
+
+    it('still unwraps a status-less success (no error, data present)', () => {
+      expect(evaluateSdkResponse({ data: { ok: 1 } }, { opId: 'x' })).toEqual({ ok: 1 });
+    });
+
+    it('still returns raw for a status-less object with neither error nor data', () => {
+      const raw = { processInstanceKey: '1' };
+      expect(evaluateSdkResponse(raw, { opId: 'x' })).toBe(raw);
+    });
+  });
+
+  describe('public surface: the class client rejects (never resolves) on a transport failure', () => {
+    it.each(OPERATIONS)('$name', async ({ call }) => {
+      const fetchMock = failingFetch();
+      const client = createCamundaClient({ config: CONFIG as any, fetch: fetchMock as any });
+      await expect(call(client)).rejects.toThrow(/fetch failed/);
+      // Prove we actually reached the transport (i.e. the rejection is the
+      // network error, not an early validation/config throw).
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('public surface: the fp client yields a Left (never a Right of nothing) on a transport failure', () => {
+    it.each(OPERATIONS)('$name', async ({ call }) => {
+      const fetchMock = failingFetch();
+      const fp = createCamundaFpClient({ config: CONFIG as any, fetch: fetchMock as any } as any);
+      const either = await (call(fp) as any)();
+      expect(isLeft(either)).toBe(true);
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Fixes the silent transport-error swallowing tracked in #405, and adds a
contract-level regression guard so this class of change can't slip through again.

## Root cause

Since **v10.0.0-alpha.18** (a generated hey-api client upgrade, commit 530031b),
`src/gen/client/client.gen.ts` `request()` wraps the whole request — *including*
`response = await _fetch(request)` — in one `try { … } catch (error) { … }`. In
the catch, with `throwOnError:false`, it **returns** `{ error, response: undefined }`
instead of rejecting. Before alpha.18 the `fetch` call was outside any try/catch,
so a transport error (DNS, `ECONNREFUSED`, unreachable host, TLS) always rejected,
independent of `throwOnError`.

Every `CamundaClient` method calls its op with `throwOnError:false` and routes the
result through `evaluateSdkResponse` (`src/runtime/responseEvaluation.ts`), which
derives a status from `raw.status || raw.response?.status || raw.error?.status`.
A transport error has none of these, so it took the `!status` branch and was
**unwrapped as success** — the operation resolved `undefined` instead of
rejecting. The fp client (`createCamundaFpClient`, which wraps the class client)
turned that into `right(undefined)`.

**Net effect: any operation silently succeeded on a failed request.**

```ts
const c = createCamundaClient({ baseUrl: "http://localhost:0" }); // nothing listening
await c.correlateMessage({ name: "x", correlationKey: "k" }); // resolved undefined (should reject)
```

## Fix

In `evaluateSdkResponse`, when there is no HTTP status but `raw.error` is present
(and no `data`), **throw** the underlying error — synthesizing a `TransportSdkError`
for non-Error causes — instead of unwrapping. This restores fail-on-transport-error
for **both** public surfaces (`.` class client and `./fp`, which both route through
here). Status-less *successes* are unchanged.

## Regression guard

`tests/transport-error-rejection.test.ts` asserts the public contract, independent
of the internal path, across a representative spread of operation shapes (GET,
POST-with-body, enriched job op, search) on **both** public surfaces:

- class client: a transport failure **rejects**;
- fp client: a transport failure yields a **Left** (never a `Right` of nothing);
- plus focused unit tests on `evaluateSdkResponse`.

Verified it genuinely catches the regression: reverting the one-line-region fix
makes **10 of 12** tests fail with *"promise resolved … instead of rejecting."*

## Validation

- New guard: 12/12 pass (and 10/12 fail without the fix).
- Full suite: `npm test` → 253 passed, 7 skipped, 0 failed.
- `tsc -p tsconfig.typecheck.json` clean; `biome check` clean on changed files.

## Note for triage (#405)

The underlying client-level behaviour — returning `{ error }` on a transport
failure when `throwOnError:false` — is unchanged here; this PR fixes the evaluator
that every class/fp operation funnels through. #405 tracks the wider audit
(whether the client should reject transport errors regardless of `throwOnError`,
and other call sites — retry/backpressure, workers, SSE — that assumed a
rejection).
