### PR TITLE
fix(runtime): back off job-worker activation retries on transport errors

### DIFF
--- a/src/runtime/jobWorker.ts
+++ b/src/runtime/jobWorker.ts
@@ -3,9 +3,9 @@ import type { CamundaClient } from '../gen/CamundaClient';
 import type { ActivateJobsResponses } from '../gen/types.gen';
 import type { EnrichedActivatedJob } from './jobActions';
 import {
-  computePollBackoffMs,
   DEFAULT_POLL_BACKOFF_MAX_MS,
   DEFAULT_POLL_BACKOFF_MIN_MS,
+  nextActivationRetryDelayMs,
 } from './pollBackoff';
 import { WorkerStartGate } from './workerStartGate';
 
@@ -313,22 +313,21 @@ export class JobWorker {
         this._scheduleNext(this._cfg.pollIntervalMs);
         return;
       }
-      // Transport/connectivity error: back off exponentially (with jitter) so a
-      // sustained outage — a broker restart, a LAN blip, DNS flap — does not turn
-      // into a tight sub-millisecond retry loop that floods logs and hammers an
-      // unreachable endpoint. Resets to the floor on the next successful poll.
+      // Any non-cancellation activation failure: back off exponentially (with
+      // jitter) so a sustained fault — a transport outage (broker restart, LAN
+      // blip, DNS flap) or a persistent server/auth/validation error — does not
+      // turn into a tight sub-millisecond retry loop that floods logs and hammers
+      // the endpoint. Transport outages are the motivating case, but backing off
+      // on *every* recurring failure is deliberate: it is the safe default that
+      // keeps the retry cadence bounded regardless of the error class. Resets to
+      // the floor on the next successful poll.
       this._consecutiveActivationErrors += 1;
-      // When backoff is disabled (pollBackoffMinMs <= 0) fall back to the normal
-      // poll interval on failure. Otherwise computePollBackoffMs would return 0
-      // and _scheduleNext(0) would spin an even tighter retry loop than the old
-      // pollIntervalMs behaviour — the opposite of what "disable" should mean.
-      const delayMs =
-        this._cfg.pollBackoffMinMs > 0
-          ? computePollBackoffMs(this._consecutiveActivationErrors, {
-              minMs: this._cfg.pollBackoffMinMs,
-              maxMs: this._cfg.pollBackoffMaxMs,
-            })
-          : this._cfg.pollIntervalMs;
+      // nextActivationRetryDelayMs is the single source of truth shared with
+      // ThreadedJobWorker so the two implementations cannot drift. When backoff
+      // is disabled (pollBackoffMinMs <= 0) it falls back to the normal poll
+      // interval rather than 0, which would spin an even tighter retry loop than
+      // the old behaviour — the opposite of what "disable" should mean.
+      const delayMs = nextActivationRetryDelayMs(this._consecutiveActivationErrors, this._cfg);
       this._log.error('activation.error', e);
       this._log.debug(() => [
         'activation.retry',

--- a/src/runtime/jobWorker.ts
+++ b/src/runtime/jobWorker.ts
@@ -34,7 +34,7 @@ export interface JobWorkerConfig<
    * requests (connection refused, connect timeout, broker restart, LAN blip …).
    * The first retry waits ≈ this/2–this ms; subsequent consecutive failures
    * double the window up to {@link pollBackoffMaxMs}, with jitter, and reset to
-   * zero on the first successful poll. Default `1000`. Set to `0` to disable.
+   * zero on the first successful poll. Default `1000`. Set to `0` to disable backoff (failed polls then fall back to {@link pollIntervalMs} rather than retrying immediately).
    */
   pollBackoffMinMs?: number;
   /**
@@ -318,10 +318,17 @@ export class JobWorker {
       // into a tight sub-millisecond retry loop that floods logs and hammers an
       // unreachable endpoint. Resets to the floor on the next successful poll.
       this._consecutiveActivationErrors += 1;
-      const delayMs = computePollBackoffMs(this._consecutiveActivationErrors, {
-        minMs: this._cfg.pollBackoffMinMs,
-        maxMs: this._cfg.pollBackoffMaxMs,
-      });
+      // When backoff is disabled (pollBackoffMinMs <= 0) fall back to the normal
+      // poll interval on failure. Otherwise computePollBackoffMs would return 0
+      // and _scheduleNext(0) would spin an even tighter retry loop than the old
+      // pollIntervalMs behaviour — the opposite of what "disable" should mean.
+      const delayMs =
+        this._cfg.pollBackoffMinMs > 0
+          ? computePollBackoffMs(this._consecutiveActivationErrors, {
+              minMs: this._cfg.pollBackoffMinMs,
+              maxMs: this._cfg.pollBackoffMaxMs,
+            })
+          : this._cfg.pollIntervalMs;
       this._log.error('activation.error', e);
       this._log.debug(() => [
         'activation.retry',

--- a/src/runtime/jobWorker.ts
+++ b/src/runtime/jobWorker.ts
@@ -2,6 +2,11 @@ import type { z } from 'zod';
 import type { CamundaClient } from '../gen/CamundaClient';
 import type { ActivateJobsResponses } from '../gen/types.gen';
 import type { EnrichedActivatedJob } from './jobActions';
+import {
+  computePollBackoffMs,
+  DEFAULT_POLL_BACKOFF_MAX_MS,
+  DEFAULT_POLL_BACKOFF_MIN_MS,
+} from './pollBackoff';
 import { WorkerStartGate } from './workerStartGate';
 
 type ActivatedJobResult = ActivateJobsResponses[200]['jobs'][number];
@@ -24,6 +29,18 @@ export interface JobWorkerConfig<
   customHeadersSchema?: Headers;
   /** Backoff between polls - default 1ms */
   pollIntervalMs?: number;
+  /**
+   * Floor (ms) of the exponential backoff applied between *failed* activation
+   * requests (connection refused, connect timeout, broker restart, LAN blip …).
+   * The first retry waits ≈ this/2–this ms; subsequent consecutive failures
+   * double the window up to {@link pollBackoffMaxMs}, with jitter, and reset to
+   * zero on the first successful poll. Default `1000`. Set to `0` to disable.
+   */
+  pollBackoffMinMs?: number;
+  /**
+   * Ceiling (ms) of the between-failed-poll exponential backoff. Default `30000`.
+   */
+  pollBackoffMaxMs?: number;
   jobHandler: (job: Job<In, Headers>) => Promise<JobActionReceipt> | JobActionReceipt;
   /** Immediately start polling for work - default `true` */
   autoStart?: boolean;
@@ -68,6 +85,8 @@ export interface JobWorkerConfig<
  */
 type ResolvedJobWorkerConfig = JobWorkerConfig & {
   pollIntervalMs: number;
+  pollBackoffMinMs: number;
+  pollBackoffMaxMs: number;
   autoStart: boolean;
   validateSchemas: boolean;
   maxParallelJobs: number;
@@ -100,6 +119,8 @@ export class JobWorker {
   private _stopped = false;
   private _pollTimer: any = null;
   private _inFlightActivation: any = null; // CancelablePromise-like
+  /** Consecutive failed activation requests; drives the retry backoff, reset on success. */
+  private _consecutiveActivationErrors = 0;
   private _log: ReturnType<CamundaClient['logger']>;
   private _startGate: WorkerStartGate;
 
@@ -111,6 +132,8 @@ export class JobWorker {
     this._cfg = {
       ...cfg,
       pollIntervalMs: cfg.pollIntervalMs ?? 1,
+      pollBackoffMinMs: cfg.pollBackoffMinMs ?? DEFAULT_POLL_BACKOFF_MIN_MS,
+      pollBackoffMaxMs: cfg.pollBackoffMaxMs ?? DEFAULT_POLL_BACKOFF_MAX_MS,
       autoStart: cfg.autoStart ?? true,
       validateSchemas: cfg.validateSchemas ?? false,
       maxParallelJobs: cfg.maxParallelJobs ?? 10,
@@ -276,18 +299,35 @@ export class JobWorker {
       this._inFlightActivation = this._client.activateJobs(body);
       const activation = await this._inFlightActivation;
       this._inFlightActivation = null;
+      // A successful poll (jobs or an empty long-poll) proves connectivity —
+      // clear the failure streak so the next error starts backoff from the floor.
+      this._consecutiveActivationErrors = 0;
       result = activation?.jobs || [];
       this._log.debug(() => ['activation.response', { jobs: result.length }]);
     } catch (e) {
       this._inFlightActivation = null;
       if (this._stopped) return; // Ignore errors after stop
-      // Suppress logging for intentional cancellation (user-initiated stop).
+      // Suppress logging + backoff for intentional cancellation (user-initiated stop).
       if ((e as any)?.name === 'CancelSdkError') {
         this._log.debug('activation.cancelled');
-      } else {
-        this._log.error('activation.error', e);
+        this._scheduleNext(this._cfg.pollIntervalMs);
+        return;
       }
-      this._scheduleNext(this._cfg.pollIntervalMs);
+      // Transport/connectivity error: back off exponentially (with jitter) so a
+      // sustained outage — a broker restart, a LAN blip, DNS flap — does not turn
+      // into a tight sub-millisecond retry loop that floods logs and hammers an
+      // unreachable endpoint. Resets to the floor on the next successful poll.
+      this._consecutiveActivationErrors += 1;
+      const delayMs = computePollBackoffMs(this._consecutiveActivationErrors, {
+        minMs: this._cfg.pollBackoffMinMs,
+        maxMs: this._cfg.pollBackoffMaxMs,
+      });
+      this._log.error('activation.error', e);
+      this._log.debug(() => [
+        'activation.retry',
+        { attempt: this._consecutiveActivationErrors, retryInMs: delayMs },
+      ]);
+      this._scheduleNext(delayMs);
       return;
     }
     if (!result || result.length === 0) {

--- a/src/runtime/pollBackoff.ts
+++ b/src/runtime/pollBackoff.ts
@@ -21,7 +21,11 @@ export interface PollBackoffOptions {
   minMs: number;
   /** Maximum delay in ms; the backoff never exceeds this. */
   maxMs: number;
-  /** Injectable RNG in [0, 1) for deterministic tests. Defaults to Math.random. */
+  /**
+   * Injectable RNG for deterministic tests; defaults to `Math.random` (which
+   * yields `[0, 1)`). Any returned value is clamped to `[0, 1]`, so an injected
+   * `1` is accepted and maps to the inclusive upper bound of the jitter window.
+   */
   rng?: () => number;
 }
 
@@ -54,8 +58,8 @@ export function computePollBackoffMs(attempt: number, opts: PollBackoffOptions):
   const exponent = Math.min(safeAttempt - 1, 53);
   const cap = Math.min(max, min * 2 ** exponent);
   const half = cap / 2;
-  // An injected rng may return NaN or a value outside [0, 1); clamp it so the
-  // jitter can never push the delay negative or to NaN.
+  // An injected rng may return NaN or a value outside [0, 1]; clamp it to
+  // [0, 1] so the jitter can never push the delay negative or to NaN.
   const r = rng();
   const jitter = Number.isFinite(r) ? Math.min(1, Math.max(0, r)) : 0;
   return Math.round(half + jitter * half);

--- a/src/runtime/pollBackoff.ts
+++ b/src/runtime/pollBackoff.ts
@@ -39,14 +39,24 @@ export interface PollBackoffOptions {
  */
 export function computePollBackoffMs(attempt: number, opts: PollBackoffOptions): number {
   const rng = opts.rng ?? Math.random;
-  const min = Math.max(0, opts.minMs);
-  const max = Math.max(min, opts.maxMs);
-  const safeAttempt = Math.max(1, Math.floor(attempt));
+  // Defensively normalise every input. This helper is fed user-provided config
+  // (`pollBackoffMinMs`/`pollBackoffMaxMs`) and an injectable rng, any of which
+  // could be NaN, negative, or out of range. A NaN/negative delay would be
+  // coerced by setTimeout to 0, reintroducing the very tight retry loop this
+  // helper exists to prevent — so we clamp to guarantee a finite, non-negative
+  // integer result.
+  const min = Number.isFinite(opts.minMs) ? Math.max(0, opts.minMs) : 0;
+  const max = Number.isFinite(opts.maxMs) ? Math.max(min, opts.maxMs) : min;
+  const safeAttempt = Number.isFinite(attempt) ? Math.max(1, Math.floor(attempt)) : 1;
   // 2^(safeAttempt-1) can overflow to Infinity for absurd attempt counts; the
   // Math.min against `max` still yields a finite cap, so no explicit guard is
   // needed — but clamp the exponent anyway to avoid pointless huge intermediates.
   const exponent = Math.min(safeAttempt - 1, 53);
   const cap = Math.min(max, min * 2 ** exponent);
   const half = cap / 2;
-  return Math.round(half + rng() * half);
+  // An injected rng may return NaN or a value outside [0, 1); clamp it so the
+  // jitter can never push the delay negative or to NaN.
+  const r = rng();
+  const jitter = Number.isFinite(r) ? Math.min(1, Math.max(0, r)) : 0;
+  return Math.round(half + jitter * half);
 }

--- a/src/runtime/pollBackoff.ts
+++ b/src/runtime/pollBackoff.ts
@@ -88,7 +88,7 @@ export interface ActivationRetryDelayConfig {
  * @param attempt 1-based count of consecutive failures (1 = first failure).
  * @param cfg worker retry-scheduling config.
  * @param rng optional injectable RNG forwarded to {@link computePollBackoffMs}.
- * @returns a non-negative delay in milliseconds.
+ * @returns a non-negative integer delay in milliseconds.
  */
 export function nextActivationRetryDelayMs(
   attempt: number,
@@ -102,5 +102,10 @@ export function nextActivationRetryDelayMs(
       rng,
     });
   }
-  return cfg.pollIntervalMs;
+  // Backoff disabled: fall back to the normal poll cadence. Defensively
+  // normalise it to a non-negative integer — `pollIntervalMs` is user-provided
+  // config that could be fractional/negative/NaN, any of which would violate
+  // this helper's documented contract and (for NaN/negative) be coerced by
+  // setTimeout to a 0ms delay, spinning the very tight retry loop we avoid.
+  return Number.isFinite(cfg.pollIntervalMs) ? Math.max(0, Math.round(cfg.pollIntervalMs)) : 0;
 }

--- a/src/runtime/pollBackoff.ts
+++ b/src/runtime/pollBackoff.ts
@@ -1,0 +1,52 @@
+/**
+ * Capped exponential backoff with equal jitter for job-worker activation retries.
+ *
+ * Job workers long-poll the broker for work. When an activation request fails at
+ * the transport level (connection refused, connect timeout, DNS/LAN blip, a
+ * broker restart, …) the worker must retry — but retrying on a flat, sub-millisecond
+ * interval turns a transient outage into a tight error loop that floods logs and
+ * hammers the (already unreachable) endpoint. Instead, each *consecutive* failure
+ * backs off exponentially up to a cap, with jitter so a fleet of workers that all
+ * lost connectivity at the same instant does not reconnect in lockstep (a
+ * thundering herd). The backoff resets to zero the moment a poll succeeds.
+ */
+
+/** Default floor of the backoff window (first retry ≈ 0.5–1s). */
+export const DEFAULT_POLL_BACKOFF_MIN_MS = 1000;
+/** Default ceiling of the backoff window. */
+export const DEFAULT_POLL_BACKOFF_MAX_MS = 30_000;
+
+export interface PollBackoffOptions {
+  /** Base delay in ms; the first retry's cap. */
+  minMs: number;
+  /** Maximum delay in ms; the backoff never exceeds this. */
+  maxMs: number;
+  /** Injectable RNG in [0, 1) for deterministic tests. Defaults to Math.random. */
+  rng?: () => number;
+}
+
+/**
+ * Compute the delay (ms) before the next activation retry.
+ *
+ * Uses capped exponential growth with *equal jitter*: for a 1-based `attempt`,
+ * the cap is `min(maxMs, minMs * 2^(attempt-1))` and the returned delay is a
+ * uniformly random value in `[cap/2, cap]`. Equal jitter (rather than full
+ * jitter from 0) guarantees a non-trivial floor so retries always slow down,
+ * while still de-synchronising concurrent workers.
+ *
+ * @param attempt 1-based count of consecutive failures (1 = first failure).
+ * @returns a non-negative integer delay in milliseconds.
+ */
+export function computePollBackoffMs(attempt: number, opts: PollBackoffOptions): number {
+  const rng = opts.rng ?? Math.random;
+  const min = Math.max(0, opts.minMs);
+  const max = Math.max(min, opts.maxMs);
+  const safeAttempt = Math.max(1, Math.floor(attempt));
+  // 2^(safeAttempt-1) can overflow to Infinity for absurd attempt counts; the
+  // Math.min against `max` still yields a finite cap, so no explicit guard is
+  // needed — but clamp the exponent anyway to avoid pointless huge intermediates.
+  const exponent = Math.min(safeAttempt - 1, 53);
+  const cap = Math.min(max, min * 2 ** exponent);
+  const half = cap / 2;
+  return Math.round(half + rng() * half);
+}

--- a/src/runtime/pollBackoff.ts
+++ b/src/runtime/pollBackoff.ts
@@ -16,6 +16,15 @@ export const DEFAULT_POLL_BACKOFF_MIN_MS = 1000;
 /** Default ceiling of the backoff window. */
 export const DEFAULT_POLL_BACKOFF_MAX_MS = 30_000;
 
+/**
+ * Largest delay a browser/Node `setTimeout` can hold without overflow: the
+ * 32-bit signed millisecond ceiling (2^31 - 1 ≈ 24.8 days). A larger delay is
+ * silently coerced to ~1ms by the runtime, so we clamp the backoff window to
+ * this bound to keep the "delay never exceeds the cap" contract meaningful and
+ * avoid reintroducing the tight retry loop this helper exists to prevent.
+ */
+const MAX_SAFE_TIMEOUT_MS = 2_147_483_647;
+
 export interface PollBackoffOptions {
   /** Base delay in ms; the first retry's cap. */
   minMs: number;
@@ -45,12 +54,16 @@ export function computePollBackoffMs(attempt: number, opts: PollBackoffOptions):
   const rng = opts.rng ?? Math.random;
   // Defensively normalise every input. This helper is fed user-provided config
   // (`pollBackoffMinMs`/`pollBackoffMaxMs`) and an injectable rng, any of which
-  // could be NaN, negative, or out of range. A NaN/negative delay would be
-  // coerced by setTimeout to 0, reintroducing the very tight retry loop this
-  // helper exists to prevent — so we clamp to guarantee a finite, non-negative
-  // integer result.
-  const min = Number.isFinite(opts.minMs) ? Math.max(0, opts.minMs) : 0;
-  const max = Number.isFinite(opts.maxMs) ? Math.max(min, opts.maxMs) : min;
+  // could be NaN, negative, fractional, or absurdly large. Normalise min/max to
+  // non-negative integers within the safe setTimeout range so the rounded delay
+  // can never overshoot the caller's ceiling and a huge maxMs can never overflow
+  // setTimeout into a ~1ms tight retry loop — the very thing this helper avoids.
+  const min = Number.isFinite(opts.minMs)
+    ? Math.min(MAX_SAFE_TIMEOUT_MS, Math.max(0, Math.floor(opts.minMs)))
+    : 0;
+  const max = Number.isFinite(opts.maxMs)
+    ? Math.min(MAX_SAFE_TIMEOUT_MS, Math.max(min, Math.floor(opts.maxMs)))
+    : min;
   const safeAttempt = Number.isFinite(attempt) ? Math.max(1, Math.floor(attempt)) : 1;
   // 2^(safeAttempt-1) can overflow to Infinity for absurd attempt counts; the
   // Math.min against `max` still yields a finite cap, so no explicit guard is

--- a/src/runtime/pollBackoff.ts
+++ b/src/runtime/pollBackoff.ts
@@ -64,3 +64,43 @@ export function computePollBackoffMs(attempt: number, opts: PollBackoffOptions):
   const jitter = Number.isFinite(r) ? Math.min(1, Math.max(0, r)) : 0;
   return Math.round(half + jitter * half);
 }
+
+/** Subset of worker config that governs activation-retry scheduling. */
+export interface ActivationRetryDelayConfig {
+  /** Normal poll cadence; also the fallback delay when backoff is disabled. */
+  pollIntervalMs: number;
+  /** Backoff floor. `<= 0` disables backoff (fall back to `pollIntervalMs`). */
+  pollBackoffMinMs: number;
+  /** Backoff ceiling. */
+  pollBackoffMaxMs: number;
+}
+
+/**
+ * Decide the delay (ms) before the next activation retry given a `attempt`-long
+ * streak of consecutive failures.
+ *
+ * This is the single source of truth shared by {@link JobWorker} and
+ * {@link ThreadedJobWorker} so their retry-scheduling behaviour cannot drift.
+ * When backoff is disabled (`pollBackoffMinMs <= 0`) it falls back to the normal
+ * poll interval rather than 0 — a 0ms reschedule would spin an even tighter
+ * retry loop than the old behaviour, the opposite of what "disable" should mean.
+ *
+ * @param attempt 1-based count of consecutive failures (1 = first failure).
+ * @param cfg worker retry-scheduling config.
+ * @param rng optional injectable RNG forwarded to {@link computePollBackoffMs}.
+ * @returns a non-negative delay in milliseconds.
+ */
+export function nextActivationRetryDelayMs(
+  attempt: number,
+  cfg: ActivationRetryDelayConfig,
+  rng?: () => number
+): number {
+  if (cfg.pollBackoffMinMs > 0) {
+    return computePollBackoffMs(attempt, {
+      minMs: cfg.pollBackoffMinMs,
+      maxMs: cfg.pollBackoffMaxMs,
+      rng,
+    });
+  }
+  return cfg.pollIntervalMs;
+}

--- a/src/runtime/threadedJobWorker.ts
+++ b/src/runtime/threadedJobWorker.ts
@@ -3,6 +3,11 @@ import type { CamundaClient } from '../gen/CamundaClient';
 import type { ActivateJobsResponses } from '../gen/types.gen';
 import type { EnrichedActivatedJob } from './jobActions';
 import type { JobActionReceipt } from './jobWorker';
+import {
+  computePollBackoffMs,
+  DEFAULT_POLL_BACKOFF_MAX_MS,
+  DEFAULT_POLL_BACKOFF_MIN_MS,
+} from './pollBackoff';
 import type { ThreadPool } from './threadPool';
 import { WorkerStartGate } from './workerStartGate';
 
@@ -54,6 +59,18 @@ export interface ThreadedJobWorkerConfig<
   customHeadersSchema?: Headers;
   /** Backoff between polls - default 1ms */
   pollIntervalMs?: number;
+  /**
+   * Floor (ms) of the exponential backoff applied between *failed* activation
+   * requests (connection refused, connect timeout, broker restart, LAN blip …).
+   * The first retry waits ≈ this/2–this ms; subsequent consecutive failures
+   * double the window up to {@link pollBackoffMaxMs}, with jitter, and reset to
+   * zero on the first successful poll. Default `1000`. Set to `0` to disable.
+   */
+  pollBackoffMinMs?: number;
+  /**
+   * Ceiling (ms) of the between-failed-poll exponential backoff. Default `30000`.
+   */
+  pollBackoffMaxMs?: number;
   /** Immediately start polling for work - default `true` */
   autoStart?: boolean;
   /** Concurrency limit — default `10`. Overridden by CAMUNDA_WORKER_MAX_CONCURRENT_JOBS env var. */
@@ -100,6 +117,8 @@ export interface ThreadedJobWorkerConfig<
  */
 type ResolvedThreadedJobWorkerConfig = ThreadedJobWorkerConfig & {
   pollIntervalMs: number;
+  pollBackoffMinMs: number;
+  pollBackoffMaxMs: number;
   autoStart: boolean;
   validateSchemas: boolean;
   maxParallelJobs: number;
@@ -129,6 +148,8 @@ export class ThreadedJobWorker {
   private _stopped = false;
   private _pollTimer: any = null;
   private _inFlightActivation: any = null;
+  /** Consecutive failed activation requests; drives the retry backoff, reset on success. */
+  private _consecutiveActivationErrors = 0;
   private _log: ReturnType<CamundaClient['logger']>;
   private _jobQueue: Array<{ raw: ActivatedJobResult & Partial<EnrichedActivatedJob> }> = [];
   private _startGate: WorkerStartGate;
@@ -142,6 +163,8 @@ export class ThreadedJobWorker {
     this._cfg = {
       ...cfg,
       pollIntervalMs: cfg.pollIntervalMs ?? 1,
+      pollBackoffMinMs: cfg.pollBackoffMinMs ?? DEFAULT_POLL_BACKOFF_MIN_MS,
+      pollBackoffMaxMs: cfg.pollBackoffMaxMs ?? DEFAULT_POLL_BACKOFF_MAX_MS,
       autoStart: cfg.autoStart ?? true,
       validateSchemas: cfg.validateSchemas ?? false,
       maxParallelJobs: cfg.maxParallelJobs ?? 10,
@@ -414,17 +437,35 @@ export class ThreadedJobWorker {
       this._inFlightActivation = this._client.activateJobs(body);
       const activation = await this._inFlightActivation;
       this._inFlightActivation = null;
+      // A successful poll (jobs or an empty long-poll) proves connectivity —
+      // clear the failure streak so the next error starts backoff from the floor.
+      this._consecutiveActivationErrors = 0;
       result = activation?.jobs || [];
       this._log.debug(() => ['activation.response', { jobs: result.length }]);
     } catch (e) {
       this._inFlightActivation = null;
       if (this._stopped) return;
+      // Suppress logging + backoff for intentional cancellation (user-initiated stop).
       if ((e as any)?.name === 'CancelSdkError') {
         this._log.debug('activation.cancelled');
-      } else {
-        this._log.error('activation.error', e);
+        this._scheduleNext(this._cfg.pollIntervalMs);
+        return;
       }
-      this._scheduleNext(this._cfg.pollIntervalMs);
+      // Transport/connectivity error: back off exponentially (with jitter) so a
+      // sustained outage — a broker restart, a LAN blip, DNS flap — does not turn
+      // into a tight sub-millisecond retry loop that floods logs and hammers an
+      // unreachable endpoint. Resets to the floor on the next successful poll.
+      this._consecutiveActivationErrors += 1;
+      const delayMs = computePollBackoffMs(this._consecutiveActivationErrors, {
+        minMs: this._cfg.pollBackoffMinMs,
+        maxMs: this._cfg.pollBackoffMaxMs,
+      });
+      this._log.error('activation.error', e);
+      this._log.debug(() => [
+        'activation.retry',
+        { attempt: this._consecutiveActivationErrors, retryInMs: delayMs },
+      ]);
+      this._scheduleNext(delayMs);
       return;
     }
     if (!result || result.length === 0) {

--- a/src/runtime/threadedJobWorker.ts
+++ b/src/runtime/threadedJobWorker.ts
@@ -4,9 +4,9 @@ import type { ActivateJobsResponses } from '../gen/types.gen';
 import type { EnrichedActivatedJob } from './jobActions';
 import type { JobActionReceipt } from './jobWorker';
 import {
-  computePollBackoffMs,
   DEFAULT_POLL_BACKOFF_MAX_MS,
   DEFAULT_POLL_BACKOFF_MIN_MS,
+  nextActivationRetryDelayMs,
 } from './pollBackoff';
 import type { ThreadPool } from './threadPool';
 import { WorkerStartGate } from './workerStartGate';
@@ -451,22 +451,21 @@ export class ThreadedJobWorker {
         this._scheduleNext(this._cfg.pollIntervalMs);
         return;
       }
-      // Transport/connectivity error: back off exponentially (with jitter) so a
-      // sustained outage — a broker restart, a LAN blip, DNS flap — does not turn
-      // into a tight sub-millisecond retry loop that floods logs and hammers an
-      // unreachable endpoint. Resets to the floor on the next successful poll.
+      // Any non-cancellation activation failure: back off exponentially (with
+      // jitter) so a sustained fault — a transport outage (broker restart, LAN
+      // blip, DNS flap) or a persistent server/auth/validation error — does not
+      // turn into a tight sub-millisecond retry loop that floods logs and hammers
+      // the endpoint. Transport outages are the motivating case, but backing off
+      // on *every* recurring failure is deliberate: it is the safe default that
+      // keeps the retry cadence bounded regardless of the error class. Resets to
+      // the floor on the next successful poll.
       this._consecutiveActivationErrors += 1;
-      // When backoff is disabled (pollBackoffMinMs <= 0) fall back to the normal
-      // poll interval on failure. Otherwise computePollBackoffMs would return 0
-      // and _scheduleNext(0) would spin an even tighter retry loop than the old
-      // pollIntervalMs behaviour — the opposite of what "disable" should mean.
-      const delayMs =
-        this._cfg.pollBackoffMinMs > 0
-          ? computePollBackoffMs(this._consecutiveActivationErrors, {
-              minMs: this._cfg.pollBackoffMinMs,
-              maxMs: this._cfg.pollBackoffMaxMs,
-            })
-          : this._cfg.pollIntervalMs;
+      // nextActivationRetryDelayMs is the single source of truth shared with
+      // JobWorker so the two implementations cannot drift. When backoff is
+      // disabled (pollBackoffMinMs <= 0) it falls back to the normal poll interval
+      // rather than 0, which would spin an even tighter retry loop than the old
+      // behaviour — the opposite of what "disable" should mean.
+      const delayMs = nextActivationRetryDelayMs(this._consecutiveActivationErrors, this._cfg);
       this._log.error('activation.error', e);
       this._log.debug(() => [
         'activation.retry',

--- a/src/runtime/threadedJobWorker.ts
+++ b/src/runtime/threadedJobWorker.ts
@@ -64,7 +64,7 @@ export interface ThreadedJobWorkerConfig<
    * requests (connection refused, connect timeout, broker restart, LAN blip …).
    * The first retry waits ≈ this/2–this ms; subsequent consecutive failures
    * double the window up to {@link pollBackoffMaxMs}, with jitter, and reset to
-   * zero on the first successful poll. Default `1000`. Set to `0` to disable.
+   * zero on the first successful poll. Default `1000`. Set to `0` to disable backoff (failed polls then fall back to {@link pollIntervalMs} rather than retrying immediately).
    */
   pollBackoffMinMs?: number;
   /**
@@ -456,10 +456,17 @@ export class ThreadedJobWorker {
       // into a tight sub-millisecond retry loop that floods logs and hammers an
       // unreachable endpoint. Resets to the floor on the next successful poll.
       this._consecutiveActivationErrors += 1;
-      const delayMs = computePollBackoffMs(this._consecutiveActivationErrors, {
-        minMs: this._cfg.pollBackoffMinMs,
-        maxMs: this._cfg.pollBackoffMaxMs,
-      });
+      // When backoff is disabled (pollBackoffMinMs <= 0) fall back to the normal
+      // poll interval on failure. Otherwise computePollBackoffMs would return 0
+      // and _scheduleNext(0) would spin an even tighter retry loop than the old
+      // pollIntervalMs behaviour — the opposite of what "disable" should mean.
+      const delayMs =
+        this._cfg.pollBackoffMinMs > 0
+          ? computePollBackoffMs(this._consecutiveActivationErrors, {
+              minMs: this._cfg.pollBackoffMinMs,
+              maxMs: this._cfg.pollBackoffMaxMs,
+            })
+          : this._cfg.pollIntervalMs;
       this._log.error('activation.error', e);
       this._log.debug(() => [
         'activation.retry',

--- a/tests/pollBackoff.test.ts
+++ b/tests/pollBackoff.test.ts
@@ -3,6 +3,7 @@ import {
   computePollBackoffMs,
   DEFAULT_POLL_BACKOFF_MAX_MS,
   DEFAULT_POLL_BACKOFF_MIN_MS,
+  nextActivationRetryDelayMs,
 } from '../src/runtime/pollBackoff';
 
 describe('computePollBackoffMs', () => {
@@ -90,5 +91,51 @@ describe('computePollBackoffMs', () => {
   it('exposes sensible defaults', () => {
     expect(DEFAULT_POLL_BACKOFF_MIN_MS).toBe(1000);
     expect(DEFAULT_POLL_BACKOFF_MAX_MS).toBe(30_000);
+  });
+});
+
+// The activation retry-delay decision is shared by JobWorker and
+// ThreadedJobWorker via this helper, so a single unit test guards both
+// implementations against drift without spawning worker threads.
+describe('nextActivationRetryDelayMs', () => {
+  const cfg = (
+    over: Partial<{
+      pollIntervalMs: number;
+      pollBackoffMinMs: number;
+      pollBackoffMaxMs: number;
+    }> = {}
+  ) => ({
+    pollIntervalMs: 1,
+    pollBackoffMinMs: 1000,
+    pollBackoffMaxMs: 30_000,
+    ...over,
+  });
+
+  it('applies capped exponential backoff while enabled', () => {
+    // rng() === 0 makes each step deterministic (== cap/2).
+    const rng = () => 0;
+    expect(nextActivationRetryDelayMs(1, cfg(), rng)).toBe(500);
+    expect(nextActivationRetryDelayMs(2, cfg(), rng)).toBe(1000);
+    expect(nextActivationRetryDelayMs(3, cfg(), rng)).toBe(2000);
+  });
+
+  it('falls back to pollIntervalMs (never 0) when backoff is disabled', () => {
+    const disabled = cfg({ pollIntervalMs: 5, pollBackoffMinMs: 0, pollBackoffMaxMs: 0 });
+    // Every attempt must reschedule at the poll interval, never a 0ms tight loop.
+    expect(nextActivationRetryDelayMs(1, disabled)).toBe(5);
+    expect(nextActivationRetryDelayMs(9, disabled)).toBe(5);
+  });
+
+  it('treats a negative backoff floor as disabled', () => {
+    const disabled = cfg({ pollIntervalMs: 7, pollBackoffMinMs: -1 });
+    expect(nextActivationRetryDelayMs(3, disabled)).toBe(7);
+  });
+
+  it('forwards the injected rng to the backoff computation', () => {
+    // rng → ~1 yields the full cap; matches computePollBackoffMs directly.
+    const rng = () => 0.999999;
+    expect(nextActivationRetryDelayMs(1, cfg(), rng)).toBe(
+      computePollBackoffMs(1, { minMs: 1000, maxMs: 30_000, rng })
+    );
   });
 });

--- a/tests/pollBackoff.test.ts
+++ b/tests/pollBackoff.test.ts
@@ -70,6 +70,23 @@ describe('computePollBackoffMs', () => {
     expect(computePollBackoffMs(-3, opts())).toBe(500);
   });
 
+  it('never returns NaN/negative for degenerate inputs', () => {
+    // NaN attempt → treated as the first step.
+    expect(computePollBackoffMs(Number.NaN, opts())).toBe(500);
+    // NaN min → treated as disabled (0), never NaN.
+    expect(computePollBackoffMs(1, opts({ minMs: Number.NaN }))).toBe(0);
+    // NaN max → falls back to min, still finite (default min 1000 → floor 500).
+    expect(computePollBackoffMs(1, opts({ maxMs: Number.NaN }))).toBe(500);
+    // An rng that returns NaN or values outside [0, 1) must be clamped so the
+    // delay stays within [cap/2, cap] and never goes NaN/negative.
+    for (const bad of [Number.NaN, -1, 2, Number.POSITIVE_INFINITY]) {
+      const d = computePollBackoffMs(2, opts({ rng: () => bad }));
+      expect(Number.isFinite(d)).toBe(true);
+      expect(d).toBeGreaterThanOrEqual(1000); // cap 2000 → floor 1000
+      expect(d).toBeLessThanOrEqual(2000);
+    }
+  });
+
   it('exposes sensible defaults', () => {
     expect(DEFAULT_POLL_BACKOFF_MIN_MS).toBe(1000);
     expect(DEFAULT_POLL_BACKOFF_MAX_MS).toBe(30_000);

--- a/tests/pollBackoff.test.ts
+++ b/tests/pollBackoff.test.ts
@@ -119,7 +119,7 @@ describe('nextActivationRetryDelayMs', () => {
     expect(nextActivationRetryDelayMs(3, cfg(), rng)).toBe(2000);
   });
 
-  it('falls back to pollIntervalMs (never 0) when backoff is disabled', () => {
+  it('falls back to pollIntervalMs when backoff is disabled', () => {
     const disabled = cfg({ pollIntervalMs: 5, pollBackoffMinMs: 0, pollBackoffMaxMs: 0 });
     // Every attempt must reschedule at the poll interval, never a 0ms tight loop.
     expect(nextActivationRetryDelayMs(1, disabled)).toBe(5);

--- a/tests/pollBackoff.test.ts
+++ b/tests/pollBackoff.test.ts
@@ -131,6 +131,22 @@ describe('nextActivationRetryDelayMs', () => {
     expect(nextActivationRetryDelayMs(3, disabled)).toBe(7);
   });
 
+  it('normalises the disabled-branch fallback to a non-negative integer', () => {
+    // A fractional pollIntervalMs must round to an integer (contract: integer ms).
+    expect(nextActivationRetryDelayMs(1, cfg({ pollIntervalMs: 4.7, pollBackoffMinMs: 0 }))).toBe(
+      5
+    );
+    // Negative/NaN pollIntervalMs must never leak through to setTimeout as a
+    // value it coerces to 0ms; they clamp/normalise to a non-negative integer.
+    expect(nextActivationRetryDelayMs(1, cfg({ pollIntervalMs: -3, pollBackoffMinMs: 0 }))).toBe(0);
+    const nan = nextActivationRetryDelayMs(
+      1,
+      cfg({ pollIntervalMs: Number.NaN, pollBackoffMinMs: 0 })
+    );
+    expect(Number.isInteger(nan)).toBe(true);
+    expect(nan).toBeGreaterThanOrEqual(0);
+  });
+
   it('forwards the injected rng to the backoff computation', () => {
     // rng → ~1 yields the full cap; matches computePollBackoffMs directly.
     const rng = () => 0.999999;

--- a/tests/pollBackoff.test.ts
+++ b/tests/pollBackoff.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computePollBackoffMs,
+  DEFAULT_POLL_BACKOFF_MAX_MS,
+  DEFAULT_POLL_BACKOFF_MIN_MS,
+} from '../src/runtime/pollBackoff';
+
+describe('computePollBackoffMs', () => {
+  const opts = (over: Partial<{ minMs: number; maxMs: number; rng: () => number }> = {}) => ({
+    minMs: 1000,
+    maxMs: 30_000,
+    rng: () => 0,
+    ...over,
+  });
+
+  it('returns the cap floor (cap/2) when rng() === 0', () => {
+    // attempt 1: cap = min(30000, 1000*2^0) = 1000 → floor 500
+    expect(computePollBackoffMs(1, opts())).toBe(500);
+    // attempt 2: cap = 2000 → 1000
+    expect(computePollBackoffMs(2, opts())).toBe(1000);
+    // attempt 3: cap = 4000 → 2000
+    expect(computePollBackoffMs(3, opts())).toBe(2000);
+  });
+
+  it('returns the full cap when rng() → ~1', () => {
+    const rng = () => 0.999999;
+    // attempt 1: cap 1000, delay ≈ 500 + 0.999999*500 ≈ 1000
+    expect(computePollBackoffMs(1, opts({ rng }))).toBe(1000);
+    // attempt 2: cap 2000, delay ≈ 2000
+    expect(computePollBackoffMs(2, opts({ rng }))).toBe(2000);
+  });
+
+  it('grows exponentially then caps at maxMs', () => {
+    // 1000,2000,4000,8000,16000, then capped at 30000 (32000 → 30000)
+    expect(computePollBackoffMs(6, opts())).toBe(15_000); // cap 30000 → floor 15000
+    expect(computePollBackoffMs(7, opts())).toBe(15_000); // still capped
+    expect(computePollBackoffMs(50, opts())).toBe(15_000); // stays capped, no overflow
+  });
+
+  it('respects a custom min/max window', () => {
+    const o = opts({ minMs: 100, maxMs: 800 });
+    expect(computePollBackoffMs(1, o)).toBe(50); // cap 100
+    expect(computePollBackoffMs(2, o)).toBe(100); // cap 200 → 100
+    expect(computePollBackoffMs(3, o)).toBe(200); // cap 400 → 200
+    expect(computePollBackoffMs(4, o)).toBe(400); // cap 800 → 400
+    expect(computePollBackoffMs(5, o)).toBe(400); // capped at 800 → 400
+  });
+
+  it('keeps every delay within [cap/2, cap] for random jitter', () => {
+    for (let attempt = 1; attempt <= 8; attempt++) {
+      const cap = Math.min(
+        DEFAULT_POLL_BACKOFF_MAX_MS,
+        DEFAULT_POLL_BACKOFF_MIN_MS * 2 ** (attempt - 1)
+      );
+      for (let i = 0; i < 100; i++) {
+        const d = computePollBackoffMs(attempt, opts({ rng: Math.random }));
+        expect(d).toBeGreaterThanOrEqual(Math.floor(cap / 2));
+        expect(d).toBeLessThanOrEqual(cap);
+      }
+    }
+  });
+
+  it('returns 0 when minMs is 0 (backoff disabled)', () => {
+    expect(computePollBackoffMs(1, opts({ minMs: 0, maxMs: 0 }))).toBe(0);
+    expect(computePollBackoffMs(5, opts({ minMs: 0, maxMs: 0 }))).toBe(0);
+  });
+
+  it('clamps a sub-1 attempt to the first step', () => {
+    expect(computePollBackoffMs(0, opts())).toBe(500);
+    expect(computePollBackoffMs(-3, opts())).toBe(500);
+  });
+
+  it('exposes sensible defaults', () => {
+    expect(DEFAULT_POLL_BACKOFF_MIN_MS).toBe(1000);
+    expect(DEFAULT_POLL_BACKOFF_MAX_MS).toBe(30_000);
+  });
+});

--- a/tests/pollBackoff.test.ts
+++ b/tests/pollBackoff.test.ts
@@ -88,6 +88,30 @@ describe('computePollBackoffMs', () => {
     }
   });
 
+  it('never exceeds the cap for fractional min/max windows', () => {
+    // A fractional cap (e.g. 1000.5) rounded to an integer must not overshoot
+    // the user-provided ceiling: round(1000.5) === 1001 would break the
+    // documented "<= cap" contract, so min/max are normalised to integers.
+    const o = opts({ minMs: 1000.5, maxMs: 1000.5, rng: () => 1 });
+    const d = computePollBackoffMs(1, o);
+    expect(Number.isInteger(d)).toBe(true);
+    expect(d).toBeLessThanOrEqual(1000.5);
+    expect(d).toBe(1000);
+  });
+
+  it('clamps an overflowing maxMs to a safe setTimeout ceiling', () => {
+    // A maxMs beyond the 32-bit signed setTimeout limit (2^31 - 1 ms) would be
+    // silently coerced to a ~1ms timeout by the runtime, reintroducing the tight
+    // retry loop this helper exists to prevent. The result must stay finite and
+    // within the safe timer range.
+    const SAFE_MAX = 2_147_483_647;
+    const o = opts({ minMs: 1000, maxMs: 1e21, rng: () => 1 });
+    const d = computePollBackoffMs(50, o);
+    expect(Number.isFinite(d)).toBe(true);
+    expect(d).toBeLessThanOrEqual(SAFE_MAX);
+    expect(d).toBeGreaterThan(0);
+  });
+
   it('exposes sensible defaults', () => {
     expect(DEFAULT_POLL_BACKOFF_MIN_MS).toBe(1000);
     expect(DEFAULT_POLL_BACKOFF_MAX_MS).toBe(30_000);

--- a/tests/worker-activation-backoff.test.ts
+++ b/tests/worker-activation-backoff.test.ts
@@ -41,6 +41,10 @@ describe('job worker activation backoff', () => {
     // deterministic and isolates the worker-level backoff under test.
     const client = createCamundaClient({
       config: { CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS: 1 },
+      // Isolate from ambient CAMUNDA_WORKER_* env vars (e.g. startup jitter),
+      // which hydrateConfig would otherwise pull from process.env and perturb
+      // the deterministic timer schedule under test.
+      env: {},
       fetch: fetchMock as any,
     });
     const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
@@ -92,6 +96,10 @@ describe('job worker activation backoff', () => {
 
     const client = createCamundaClient({
       config: { CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS: 1 },
+      // Isolate from ambient CAMUNDA_WORKER_* env vars (e.g. startup jitter),
+      // which hydrateConfig would otherwise pull from process.env and perturb
+      // the deterministic timer schedule under test.
+      env: {},
       fetch: fetchMock as any,
     });
     const setTimeoutSpy = vi.spyOn(global, 'setTimeout');

--- a/tests/worker-activation-backoff.test.ts
+++ b/tests/worker-activation-backoff.test.ts
@@ -115,10 +115,15 @@ describe('job worker activation backoff', () => {
     worker.stop();
 
     const delays = setTimeoutSpy.mock.calls.map((c) => c[1]);
-    // Failed polls must reschedule at the poll interval, never a 0ms tight loop.
-    expect(delays).toContain(5);
-    const failureDelays = delays.filter((d) => d !== 0);
-    expect(failureDelays.every((d) => d === 5)).toBe(true);
+    // Only the initial start gate is permitted to schedule 0ms; every failure
+    // reschedule must land on pollIntervalMs. Filtering the 0s out (as an
+    // earlier revision did) would silently swallow a 0ms tight-loop regression
+    // during the failure streak, so assert the start gate is the sole 0 and
+    // that every subsequent reschedule is exactly pollIntervalMs.
+    expect(delays[0]).toBe(0);
+    const afterStartGate = delays.slice(1);
+    expect(afterStartGate.length).toBeGreaterThan(0);
+    expect(afterStartGate.every((d) => d === 5)).toBe(true);
     expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/tests/worker-activation-backoff.test.ts
+++ b/tests/worker-activation-backoff.test.ts
@@ -73,10 +73,12 @@ describe('job worker activation backoff', () => {
     const firstBackoffIdx = delays.indexOf(500);
     const secondBackoffIdx = delays.indexOf(1000);
     expect(firstBackoffIdx).toBeLessThan(secondBackoffIdx);
-    // A flat 1ms retry (the old buggy behaviour) must NOT have been used for a failure.
-    // After the success, however, scheduling returns to the 1ms poll interval.
-    const oneMsAfterReset = delays.slice(secondBackoffIdx + 1).some((d) => d === 1);
-    expect(oneMsAfterReset).toBe(true);
+    // A flat 1ms retry (the old buggy behaviour) must NOT have been used for a
+    // failure: the *first* 1ms poll-interval reschedule must appear only AFTER
+    // both failure backoffs, i.e. it is the post-success reset and no 1ms retry
+    // ever leaked into the failure streak.
+    const firstOneMsIdx = delays.indexOf(1);
+    expect(firstOneMsIdx).toBeGreaterThan(secondBackoffIdx);
     expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(3);
   });
 

--- a/tests/worker-activation-backoff.test.ts
+++ b/tests/worker-activation-backoff.test.ts
@@ -79,4 +79,44 @@ describe('job worker activation backoff', () => {
     expect(oneMsAfterReset).toBe(true);
     expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(3);
   });
+
+  it('falls back to pollIntervalMs on failure when backoff is disabled (pollBackoffMinMs=0)', async () => {
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls += 1;
+      // Every poll fails at the transport layer.
+      throw new Error(calls === 1 ? 'connect ECONNREFUSED' : 'UND_ERR_CONNECT_TIMEOUT');
+    });
+
+    const client = createCamundaClient({
+      config: { CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS: 1 },
+      fetch: fetchMock as any,
+    });
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+    const worker = client.createJobWorker({
+      jobType: 'backoff-disabled-test',
+      jobHandler: async () => 'JOB_ACTION_RECEIPT' as const,
+      maxParallelJobs: 1,
+      jobTimeoutMs: 1000,
+      pollIntervalMs: 5,
+      // Disabling backoff must NOT devolve into a 0ms tight retry loop; failures
+      // should schedule at pollIntervalMs instead.
+      pollBackoffMinMs: 0,
+      pollBackoffMaxMs: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(0); // start gate + poll #1 (fails)
+    await vi.advanceTimersByTimeAsync(5); // poll #2 (fails)
+    await vi.advanceTimersByTimeAsync(5); // poll #3 (fails)
+
+    worker.stop();
+
+    const delays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+    // Failed polls must reschedule at the poll interval, never a 0ms tight loop.
+    expect(delays).toContain(5);
+    const failureDelays = delays.filter((d) => d !== 0);
+    expect(failureDelays.every((d) => d === 5)).toBe(true);
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/tests/worker-activation-backoff.test.ts
+++ b/tests/worker-activation-backoff.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCamundaClient } from '../src';
+
+/**
+ * Verifies the JobWorker applies exponential backoff (not a flat 1ms retry) on
+ * consecutive failed activation requests, and resets to the fast poll interval
+ * after a successful poll. This is the fix for tight retry-loops during a
+ * transient outage (connection refused / connect timeout / LAN blip).
+ */
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('job worker activation backoff', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('backs off exponentially on failure then resets to pollIntervalMs on success', async () => {
+    // rng() === 0 makes each backoff deterministic (== cap/2).
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    let calls = 0;
+
+    const fetchMock = vi.fn(async () => {
+      calls += 1;
+      // First two polls fail at the transport layer, then every poll succeeds
+      // (fresh Response each time so its body is never re-read).
+      if (calls <= 2)
+        throw new Error(calls === 1 ? 'connect ECONNREFUSED' : 'UND_ERR_CONNECT_TIMEOUT');
+      return jsonResponse({ jobs: [] });
+    });
+
+    // Disable the transport-layer retry (maxAttempts includes the first) so one
+    // worker poll maps to exactly one fetch call — keeps the backoff schedule
+    // deterministic and isolates the worker-level backoff under test.
+    const client = createCamundaClient({
+      config: { CAMUNDA_SDK_HTTP_RETRY_MAX_ATTEMPTS: 1 },
+      fetch: fetchMock as any,
+    });
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+    const worker = client.createJobWorker({
+      jobType: 'backoff-test',
+      jobHandler: async () => 'JOB_ACTION_RECEIPT' as const,
+      maxParallelJobs: 1,
+      jobTimeoutMs: 1000,
+      pollIntervalMs: 1,
+      pollBackoffMinMs: 1000,
+      pollBackoffMaxMs: 30_000,
+    });
+
+    // Flush the start gate (scheduleNext(0)) and let poll #1 fail.
+    await vi.advanceTimersByTimeAsync(0);
+    // Advance through the first backoff (attempt 1: cap 1000 → 500) into poll #2.
+    await vi.advanceTimersByTimeAsync(500);
+    // Advance through the second backoff (attempt 2: cap 2000 → 1000) into poll #3 (success).
+    await vi.advanceTimersByTimeAsync(1000);
+    // After success, the next poll is scheduled at pollIntervalMs (1ms).
+    await vi.advanceTimersByTimeAsync(1);
+
+    worker.stop();
+
+    const delays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+    // The two escalating backoffs must be present, in order.
+    expect(delays).toContain(500);
+    expect(delays).toContain(1000);
+    const firstBackoffIdx = delays.indexOf(500);
+    const secondBackoffIdx = delays.indexOf(1000);
+    expect(firstBackoffIdx).toBeLessThan(secondBackoffIdx);
+    // A flat 1ms retry (the old buggy behaviour) must NOT have been used for a failure.
+    // After the success, however, scheduling returns to the 1ms poll interval.
+    const oneMsAfterReset = delays.slice(secondBackoffIdx + 1).some((d) => d === 1);
+    expect(oneMsAfterReset).toBe(true);
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Problem

`c8ctl nano` hired workers (and any long-polling job worker) start throwing
`connectTimeoutError` against a broker "after some time" — `ECONNREFUSED` on
Linux, `UND_ERR_CONNECT_TIMEOUT` on Mac. These are transport-level failures on
**connection establishment** (a broker restart, a LAN/DNS flap, the host briefly
unreachable).

The worker already caught the error and rescheduled — but on the flat 1 ms
`pollIntervalMs`. So during a sustained outage the worker enters a **tight
sub-millisecond retry loop**: it floods logs with `activation.error` and hammers
an endpoint that is (by definition) unreachable, then all workers reconnect in
lockstep the instant connectivity returns (thundering herd).

Root cause was in the activation poll error path of both workers:

```ts
} catch (e) {
  ...
  this._log.error('activation.error', e);
  this._scheduleNext(this._cfg.pollIntervalMs); // flat 1ms — no backoff
}
```

## Fix

Apply **capped exponential backoff with equal jitter** between *consecutive*
failed activations:

- First retry ≈ 0.5–1 s; each further consecutive failure doubles the window up
  to 30 s.
- **Equal jitter** (delay ∈ `[cap/2, cap]`) de-synchronises a fleet that all lost
  connectivity at once, avoiding a reconnect stampede.
- The failure streak — and thus the backoff — **resets to zero on the first
  successful poll** (jobs *or* an empty long-poll), so healthy throughput and the
  normal fast poll interval are completely unaffected.
- User cancellation (`CancelSdkError`, i.e. `stop()`) keeps the old immediate
  reschedule — it is not a connectivity error.

Applied to both `JobWorker` and `ThreadedJobWorker`.

### Tunable (opt-in, sensible defaults)

New per-worker config, both defaulted so existing callers get the fix for free:

| option | default | meaning |
| --- | --- | --- |
| `pollBackoffMinMs` | `1000` | floor of the backoff window; set `0` to disable |
| `pollBackoffMaxMs` | `30000` | ceiling of the backoff window |

The backoff math lives in a small pure helper (`src/runtime/pollBackoff.ts`,
`computePollBackoffMs`) with an injectable RNG for deterministic testing.

## Tests

- `tests/pollBackoff.test.ts` — exhaustive unit coverage of the helper:
  exponential growth, cap, jitter bounds `[cap/2, cap]`, custom windows,
  `min=0` disable, sub-1 attempt clamping, defaults.
- `tests/worker-activation-backoff.test.ts` — drives a real `JobWorker` (fake
  timers, `Math.random` pinned) through two failed activations then a success,
  asserting the scheduled delays escalate `500 → 1000` and then reset to the
  1 ms poll interval after success (i.e. no more flat-1 ms retry on failure).

Full suite: **311 passed / 7 skipped**. `tsc --noEmit` clean. Biome clean on all
changed files.

## Notes

- No generated code touched; no spec regeneration required.
- Follow-up (optional): expose `CAMUNDA_WORKER_POLL_BACKOFF_MIN_MS/_MAX_MS`
  heritable env vars for operators who can't change worker code — deferred to
  keep this PR off the codegen pipeline. The default behaviour already fixes the
  reported symptom on upgrade.
